### PR TITLE
Task6816: Remove logic selecting default tag if not manually added.

### DIFF
--- a/DelegationStation/Pages/Devices.razor
+++ b/DelegationStation/Pages/Devices.razor
@@ -234,12 +234,7 @@
     {
         try
         {
-            string Id = deviceTags.Select(t => t.Id.ToString()).FirstOrDefault() ?? "";
-            if(newDevice.Tags.Count < 1 && !string.IsNullOrEmpty(Id))
-            {
-                newDevice.Tags.Add(Id);
-            }
-            else if (newDevice.Tags.Count < 1)
+            if (newDevice.Tags.Count < 1)
             {
                 deviceAddValidationMessage = "Device must have at least one Tag";
                 return;


### PR DESCRIPTION
User will now get an error if they try to add a device without selecting a tag.