### PR TITLE
US13258: Function Settings improvements

### DIFF
--- a/UpdateDevices/Interfaces/ICosmosDbService.cs
+++ b/UpdateDevices/Interfaces/ICosmosDbService.cs
@@ -1,4 +1,5 @@
 ﻿using DelegationStationShared.Models;
+using System;
 using System.Threading.Tasks;
 using UpdateDevices.Models;
 
@@ -7,7 +8,7 @@ namespace UpdateDevices.Interfaces
   public interface ICosmosDbService
   {
     Task<FunctionSettings> GetFunctionSettings();
-    Task UpdateFunctionSettings();
+    Task UpdateFunctionSettings(DateTime thisRun);
 
     Task<Device> GetDevice(string make, string model, string serialNumber);
 

--- a/UpdateDevices/Models/FunctionSettings.cs
+++ b/UpdateDevices/Models/FunctionSettings.cs
@@ -18,5 +18,11 @@ namespace UpdateDevices.Models
             PartitionKey = "FunctionSettings";
             LastRun = null;
         }
+
+        public override string ToString()
+        {
+            string output = $"LastRun: {LastRun}";
+            return output;
+        }
     }
 }

--- a/UpdateDevices/Services/CosmosDbService.cs
+++ b/UpdateDevices/Services/CosmosDbService.cs
@@ -131,7 +131,7 @@ namespace UpdateDevices.Services
       try
       {
         settings = await _container.ReadItemAsync<FunctionSettings>(settings.Id.ToString(), new PartitionKey(settings.PartitionKey));
-        _logger.DSLogInformation($"Successfully retrieved function settings.", fullMethodName);
+        _logger.DSLogInformation($"Successfully retrieved function settings:  " + settings.ToString(), fullMethodName);
       }
       catch (Exception ex)
       {
@@ -148,18 +148,18 @@ namespace UpdateDevices.Services
       return settings;
     }
 
-    public async Task UpdateFunctionSettings()
+    public async Task UpdateFunctionSettings(DateTime thisRun)
     {
       string methodName = ExtensionHelper.GetMethodName();
       string className = this.GetType().Name;
       string fullMethodName = className + "." + methodName;
 
       FunctionSettings settings = new FunctionSettings();
-      settings.LastRun = DateTime.UtcNow;
+      settings.LastRun = thisRun;
       try
       {
         var response = await _container.UpsertItemAsync<FunctionSettings>(settings, new PartitionKey(settings.PartitionKey));
-        _logger.DSLogInformation($"Successfully updated function settings.", fullMethodName);
+        _logger.DSLogInformation($"Successfully updated function settings:  " + settings.ToString(), fullMethodName);
       }
       catch (Exception ex)
       {


### PR DESCRIPTION
Changed LastRun to save value to time the function retrieves devices from Graph instead of at the end of the run to ensure coverage if the process is running long.
Adding logging of FunctionSettings values on retrieval and update to improve troubleshooting.