### PR TITLE
WebApp Bug Fixes

### DIFF
--- a/.github/workflows/software-build.yml
+++ b/.github/workflows/software-build.yml
@@ -7,6 +7,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  statuses: write
+  checks: write
 env:
   CONFIGURATION: Release
   DOTNET_CORE_VERSION: 8.0.x
@@ -18,8 +21,6 @@ env:
   AZURE_UPDATE_FUNCTION_PACKAGE_PATH: .\UpdateDevices\published
   AZURE_UPDATE_FUNCTION_PKG_NAME: update-function
 
-  AZURE_WEBJOB_PACKAGE_PATH: .\WhiteSpaceCleaner\published
-  AZURE_WEBJOB_PKG_NAME: webjob
 
 jobs:
   build:
@@ -28,26 +29,45 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ env.DOTNET_CORE_VERSION }}
+
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Setup NuGet      
+      uses: NuGet/setup-nuget@v1.0.5
+        
+    - name: Setup VSTest
+      uses: darenm/Setup-VSTest@v1      
         
     - name: Restore dependencies
-      run: dotnet restore
-      
-    - name: Build
+      run: dotnet restore  
+
+    - name: Build #Test Project
       run: |
-        dotnet build ${{ env.SRC_DIR }}/DelegationSharedLibrary --configuration ${{ env.CONFIGURATION}} --no-restore
-        dotnet build ${{ env.SRC_DIR }}/DelegationStation --configuration ${{ env.CONFIGURATION}} --no-restore
-        dotnet build ${{ env.SRC_DIR }}/UpdateDevices --configuration ${{ env.CONFIGURATION}} --no-restore
-        dotnet build ${{ env.SRC_DIR }}/WhiteSpaceCleaner --configuration ${{ env.CONFIGURATION}} --no-restore
-        # dotnet build ${{ env.SRC_DIR }}/DelegationStationTests --configuration ${{ env.CONFIGURATION}} --no-restore
+        msbuild.exe ${{ env.SRC_DIR }}/DelegationStation.sln /p:platform="Any CPU" /p:configuration="Release"       
+
+    - name: Run Tests
+      continue-on-error: true
+      run: |
+        vstest.console.exe ${{ env.SRC_DIR }}/DelegationStationTests/bin/Release/net8.0/DelegationStationTests.dll /logger:trx
+       
+    - name: Visualize Results
+      uses: dorny/test-reporter@v1
+      if: success() || failure()
+      with:
+        name: Unit Tests
+        path: ${{ env.SRC_DIR }}/TestResults/*
+        reporter: dotnet-trx
+        fail-on-error: 'false'
 
     - name: Publish
       run: |
         dotnet publish ${{ env.SRC_DIR }}/DelegationStation --configuration ${{ env.CONFIGURATION}} --no-build --output "${{ env.AZURE_APP_PACKAGE_PATH }}"
-        dotnet publish ${{ env.SRC_DIR }}/WhiteSpaceCleaner --configuration ${{ env.CONFIGURATION}} --no-build --output "${{ env.AZURE_WEBJOB_PACKAGE_PATH }}"
         dotnet publish ${{ env.SRC_DIR }}/UpdateDevices --configuration ${{ env.CONFIGURATION}} --no-build --output "${{ env.AZURE_UPDATE_FUNCTION_PACKAGE_PATH }}"
       
     - name: Upload WebApp Artifact
@@ -55,12 +75,6 @@ jobs:
       with:
         name: ${{ env.AZURE_APP_PKG_NAME }}
         path: ${{ env.AZURE_APP_PACKAGE_PATH }}
-
-    - name: Upload WebJob Artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: ${{ env.AZURE_WEBJOB_PKG_NAME }}
-        path: ${{ env.AZURE_WEBJOB_PACKAGE_PATH }}
 
     - name: Upload Update Function Artifact
       uses: actions/upload-artifact@v3

--- a/DelegationSharedLibrary/Models/DeviceUpdateAction.cs
+++ b/DelegationSharedLibrary/Models/DeviceUpdateAction.cs
@@ -44,7 +44,7 @@ namespace DelegationStationShared.Models
     public enum DeviceUpdateActionType
     {
         Attribute,
-        Group,
-        AdministrativeUnit
+        AdministrativeUnit,
+        Group
     }
 }

--- a/DelegationSharedLibrary/Models/DeviceUpdateAction.cs
+++ b/DelegationSharedLibrary/Models/DeviceUpdateAction.cs
@@ -44,7 +44,7 @@ namespace DelegationStationShared.Models
     public enum DeviceUpdateActionType
     {
         Attribute,
-        AdministrativeUnit,
-        Group
+        Group,
+        AdministrativeUnit
     }
 }

--- a/DelegationStation/Pages/Devices.razor
+++ b/DelegationStation/Pages/Devices.razor
@@ -134,13 +134,16 @@
                 </div>
             }
         }
+
+       <ConfirmMessage MessageBody=@confirmMessage ConfirmAction="@(() => DeleteDevice())" @ref="ConfirmDelete" />
+
     </Authorized>
+
     <NotAuthorized>
         <p>Not Authorized</p>
     </NotAuthorized>
 </AuthorizeView>
 
-<ConfirmMessage MessageBody=@confirmMessage ConfirmAction="@(() => DeleteDevice())" @ref="ConfirmDelete" />
 
 
 

--- a/DelegationStation/Pages/TagEdit.razor
+++ b/DelegationStation/Pages/TagEdit.razor
@@ -190,7 +190,7 @@
                                             <td>
                                             @if(ActionAllowed(a))
                                             {
-                                              <button type="button" class="btn btn-danger @onclick=@(ActionAllowed(a) ? (() => tag.UpdateActions.Remove(a)) : (() => {}))"><span class="oi oi-trash"></span> Delete</button>
+                                              <button type="button" class="btn btn-danger" @onclick=@(ActionAllowed(a) ? (() => tag.UpdateActions.Remove(a)) : (() => {}))><span class="oi oi-trash"></span> Delete</button>
                                             }
                                             </td>
                                         </tr>

--- a/DelegationStation/Pages/TagEdit.razor
+++ b/DelegationStation/Pages/TagEdit.razor
@@ -190,7 +190,7 @@
                                             <td>
                                             @if(ActionAllowed(a))
                                             {
-                                              <button type="button" class="btn btn-danger @(ActionAllowed(a) ? "" : "disabled")" @onclick=@(ActionAllowed(a) ? (() => tag.UpdateActions.Remove(a)) : (() => {}))><span class="oi oi-trash"></span> Delete</button>
+                                              <button type="button" class="btn btn-danger @onclick=@(ActionAllowed(a) ? (() => tag.UpdateActions.Remove(a)) : (() => {}))"><span class="oi oi-trash"></span> Delete</button>
                                             }
                                             </td>
                                         </tr>

--- a/DelegationStation/Pages/TagEdit.razor
+++ b/DelegationStation/Pages/TagEdit.razor
@@ -203,9 +203,9 @@
 
                                 @foreach (DeviceUpdateActionType t in Enum.GetValues(typeof(DeviceUpdateActionType)))
                                 {
-                                    if (t == DeviceUpdateActionType.Group)
+                                    if (t == DeviceUpdateActionType.Attribute)
                                     {
-                                        <AuthorizeView Context="TagGroupUpdateOption" Policy="TagUpdateActionSecurityGroups" Resource="_tag">
+                                        <AuthorizeView Context="TagAttributeUpdateOption" Policy="TagUpdateActionAttributes" Resource="_tag">
                                             <Authorized>
                                                 <option value="@t">@t</option>
                                             </Authorized>
@@ -221,14 +221,15 @@
                                         </AuthorizeView>
                                     }
 
-                                    if (t == DeviceUpdateActionType.Attribute)
+                                    if (t == DeviceUpdateActionType.Group)
                                     {
-                                        <AuthorizeView Context="TagAttributeUpdateOption" Policy="TagUpdateActionAttributes" Resource="_tag">
+                                        <AuthorizeView Context="TagGroupUpdateOption" Policy="TagUpdateActionSecurityGroups" Resource="_tag">
                                             <Authorized>
                                                 <option value="@t">@t</option>
                                             </Authorized>
                                         </AuthorizeView>
                                     }
+
                                 }
                             </select>
                             <ValidationMessage For=@(() => deviceUpdateAction.ActionType) />

--- a/DelegationStation/Pages/TagEdit.razor
+++ b/DelegationStation/Pages/TagEdit.razor
@@ -36,124 +36,124 @@
                         <InputText @bind-Value=tag.Name class="form-control"></InputText>
                         <label>Description:</label>
                         <InputTextArea @bind-Value=tag.Description class="form-control"></InputTextArea>
-                              <label class="my-1">Allowed User Principal Name RegEx:</label>
-<InputText @bind-Value=tag.AllowedUserPrincipalName @oninput=@ClearTestEnrollmentResult class="form-control"></InputText>
-<div class="border rounded my-3 p-3">
-    <h4>Validate RegEx</h4>
-    <label>Enter Test User Principal Name:</label>
-    <InputText @bind-Value=testEnrollmentUser @oninput=@ClearTestEnrollmentResult class="form-control"></InputText>
-    <button type="button" @onclick=@ValidateTestEnrollmentUser class="btn btn-primary my-2">Test</button>
-    @if (displayTestResult)
-    {
-        @if (testEnrollmentUserResult == null)
-        {
-            <p class="text-success">Invalid Regular Expression</p>
-        }
-        else if (testEnrollmentUserResult == true)
-        {
-            <p class="text-success">User is allowed to enroll</p>
-        }
-        else
-        {
-            <p class="text-danger">User is not allowed to enroll</p>
-        }
-    }
-</div>
+                        <label class="my-1">Allowed User Principal Name RegEx:</label>
+                        <InputText @bind-Value=tag.AllowedUserPrincipalName @oninput=@ClearTestEnrollmentResult class="form-control"></InputText>
+                        <div class="border rounded my-3 p-3">
+                            <h4>Validate RegEx</h4>
+                            <label>Enter Test User Principal Name:</label>
+                            <InputText @bind-Value=testEnrollmentUser @oninput=@ClearTestEnrollmentResult class="form-control"></InputText>
+                            <button type="button" @onclick=@ValidateTestEnrollmentUser class="btn btn-primary my-2">Test</button>
+                            @if (displayTestResult)
+                            {
+                                @if (testEnrollmentUserResult == null)
+                                {
+                                    <p class="text-success">Invalid Regular Expression</p>
+                                }
+                                else if (testEnrollmentUserResult == true)
+                                {
+                                    <p class="text-success">User is allowed to enroll</p>
+                                }
+                                else
+                                {
+                                    <p class="text-danger">User is not allowed to enroll</p>
+                                }
+                            }
+                        </div>
                         <br />
                         <hr />
 
                         <div class="container">
-                    <h2>Assigned Groups</h2>
-                    <table class="table table-responsive">
-                        <thead>
-                            <tr>
-                                <th>Role</th>
-                                <th>Security Group Name</th>
-                                <th>Security Group Id</th>
-                                <th></th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @foreach (RoleDelegation r in tag.RoleDelegations)
-                            {
-                                <tr>
-                                    <td>@r.Role.Name</td>
-                                    <td>@r.SecurityGroupName</td>
-                                    <td>@r.SecurityGroupId</td>
-                                    <td><button type="button" class="btn btn-danger @(authorizationService.AuthorizeAsync(authContext.User, _tag, Authorization.DeviceTagOperations.Update).Result.Succeeded ? "" : "disabled")" @onclick=@(() => tag.RoleDelegations.Remove(r))><span class="oi oi-trash"></span> Delete</button></td>
-                                </tr>
-                            }
-                        </tbody>
-                    </table>
-                </div>
-
-                    <DisplayMessage Message="@addRoleMessage" />
-                    <EditForm Model="@roleDelegation" OnValidSubmit="AddRoleDelegation" class="form-control mb-3">
-                        <DataAnnotationsValidator />
-                        <ValidationSummary />
-                        Role:
-                        <select value="@roleDelegation.Role.Id" @onchange=@((e) => UpdateRole(e)) class="form-select">
-                            <option></option>
-                            @foreach (Role r in roles)
-                            {
-                                <option value="@r.Id">@r.Name</option>
-                            }
-                        </select>
-
-                        @if (!string.IsNullOrEmpty(roleDelegation.SecurityGroupName))
-                        {
-                            <p class="mt-2 mb-2">@roleDelegation.SecurityGroupName</p>
-                            <p class="mt-2 mb-2">@roleDelegation.SecurityGroupId</p>
-                        }
-                        else if (string.IsNullOrEmpty(roleDelegation.Role.Name))
-                        {
-                            <p class="mt-2 mb-2">Select a role</p>
-                        }
-                        else
-                        {
-                            <p class="mt-2 mb-2">Select a security group</p>
-                        }
-
-                        <DisplayMessage Message=@roleSecurityGroupSearchMessage />
-                        <InputText class="form-control" @bind-Value=roleSecurityGroupSearchString placeholder="Search for a group"></InputText>
-                        <button type="button" class="btn btn-secondary mt-2 @(roleSecurityGroupSearchInProgress ? "disabled" : "")" @onclick=@(() => RoleSearchSecurityGroups()) @onkeyup=@RoleSearchSecurityGroupsKeyUp>Search</button>
-                        @if (roleSecurityGroupSearchResults.Count > 0)
-                        {
+                            <h2>Assigned Groups</h2>
                             <table class="table table-responsive">
                                 <thead>
                                     <tr>
-                                        <th>Display Name</th>
-                                        <th>Description</th>
-                                        <th>Object Id</th>
+                                        <th>Role</th>
+                                        <th>Security Group Name</th>
+                                        <th>Security Group Id</th>
                                         <th></th>
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    @foreach (Group g in roleSecurityGroupSearchResults)
+                                    @foreach (RoleDelegation r in tag.RoleDelegations)
                                     {
-                                        <tr class="">
-
-                                            <td class="clickable" @onclick=@(() => RoleSelectSecurityGroup(g))>@g.DisplayName</td>
-                                            <td class="clickable" @onclick=@(() => RoleSelectSecurityGroup(g))>@g.Description</td>
-                                            <td class="clickable" @onclick=@(() => RoleSelectSecurityGroup(g))>@g.Id</td>
-                                            <td><button type="button" class="btn btn-primary" @onclick=@(() => RoleSelectSecurityGroup(g))>Select</button></td>
+                                        <tr>
+                                            <td>@r.Role.Name</td>
+                                            <td>@r.SecurityGroupName</td>
+                                            <td>@r.SecurityGroupId</td>
+                                            <td><button type="button" class="btn btn-danger @(authorizationService.AuthorizeAsync(authContext.User, _tag, Authorization.DeviceTagOperations.Update).Result.Succeeded ? "" : "disabled")" @onclick=@(() => tag.RoleDelegations.Remove(r))><span class="oi oi-trash"></span> Delete</button></td>
                                         </tr>
                                     }
                                 </tbody>
                             </table>
-                        }
-                        else if (roleSecurityGroupSearchInProgress)
-                        {
-                            <p class="mt-2 mb-2">Searching...</p>
-                        }
-                        else if (roleSecurityGroupSearchResults.Count == 0 && roleSecurityGroupSearchExecuted)
-                        {
-                            <p class="mt-2 mb-2">No results found</p>
-                        }
-                        <br />
-                        <input type="submit" class="btn btn-primary mt-2 mb-2 @(string.IsNullOrEmpty(roleDelegation.SecurityGroupName) || string.IsNullOrEmpty(roleDelegation.Role.Name) ? "disabled" : "")" value="Add Role" />
-                    </EditForm>
-                
+                        </div>
+
+                        <DisplayMessage Message="@addRoleMessage" />
+                        <EditForm Model="@roleDelegation" OnValidSubmit="AddRoleDelegation" class="form-control mb-3">
+                            <DataAnnotationsValidator />
+                            <ValidationSummary />
+                            Role:
+                            <select value="@roleDelegation.Role.Id" @onchange=@((e) => UpdateRole(e)) class="form-select">
+                                <option></option>
+                                @foreach (Role r in roles)
+                                {
+                                    <option value="@r.Id">@r.Name</option>
+                                }
+                            </select>
+
+                            @if (!string.IsNullOrEmpty(roleDelegation.SecurityGroupName))
+                            {
+                                <p class="mt-2 mb-2">@roleDelegation.SecurityGroupName</p>
+                                <p class="mt-2 mb-2">@roleDelegation.SecurityGroupId</p>
+                            }
+                            else if (string.IsNullOrEmpty(roleDelegation.Role.Name))
+                            {
+                                <p class="mt-2 mb-2">Select a role</p>
+                            }
+                            else
+                            {
+                                <p class="mt-2 mb-2">Select a security group</p>
+                            }
+
+                            <DisplayMessage Message=@roleSecurityGroupSearchMessage />
+                            <InputText class="form-control" @bind-Value=roleSecurityGroupSearchString placeholder="Search for a group"></InputText>
+                            <button type="button" class="btn btn-secondary mt-2 @(roleSecurityGroupSearchInProgress ? "disabled" : "")" @onclick=@(() => RoleSearchSecurityGroups()) @onkeyup=@RoleSearchSecurityGroupsKeyUp>Search</button>
+                            @if (roleSecurityGroupSearchResults.Count > 0)
+                            {
+                                <table class="table table-responsive">
+                                    <thead>
+                                        <tr>
+                                            <th>Display Name</th>
+                                            <th>Description</th>
+                                            <th>Object Id</th>
+                                            <th></th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach (Group g in roleSecurityGroupSearchResults)
+                                        {
+                                            <tr class="">
+
+                                                <td class="clickable" @onclick=@(() => RoleSelectSecurityGroup(g))>@g.DisplayName</td>
+                                                <td class="clickable" @onclick=@(() => RoleSelectSecurityGroup(g))>@g.Description</td>
+                                                <td class="clickable" @onclick=@(() => RoleSelectSecurityGroup(g))>@g.Id</td>
+                                                <td><button type="button" class="btn btn-primary" @onclick=@(() => RoleSelectSecurityGroup(g))>Select</button></td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                </table>
+                            }
+                            else if (roleSecurityGroupSearchInProgress)
+                            {
+                                <p class="mt-2 mb-2">Searching...</p>
+                            }
+                            else if (roleSecurityGroupSearchResults.Count == 0 && roleSecurityGroupSearchExecuted)
+                            {
+                                <p class="mt-2 mb-2">No results found</p>
+                            }
+                            <br />
+                            <input type="submit" class="btn btn-primary mt-2 mb-2 @(string.IsNullOrEmpty(roleDelegation.SecurityGroupName) || string.IsNullOrEmpty(roleDelegation.Role.Name) ? "disabled" : "")" value="Add Role" />
+                        </EditForm>
+
                     </Authorized>
                     <NotAuthorized>
                         <label>Name:</label>
@@ -164,9 +164,9 @@
                         <hr />
                     </NotAuthorized>
                 </AuthorizeView>
-                
 
-                
+
+
                 <AuthorizeView Context="TagLimitedUpdateContext" Policy="TagUpdateActions" Resource="_tag">
                     <Authorized>
                         <div class="container">
@@ -188,10 +188,10 @@
                                             <td>@a.Name</td>
                                             <td>@a.Value</td>
                                             <td>
-                                            @if(ActionAllowed(a))
-                                            {
-                                              <button type="button" class="btn btn-danger" @onclick=@(ActionAllowed(a) ? (() => tag.UpdateActions.Remove(a)) : (() => {}))><span class="oi oi-trash"></span> Delete</button>
-                                            }
+                                                @if(ActionAllowed(a))
+                                                {
+                                                    <button type="button" class="btn btn-danger" @onclick=@(ActionAllowed(a) ? (() => tag.UpdateActions.Remove(a)) : (() => {}))><span class="oi oi-trash"></span> Delete</button>
+                                                }
                                             </td>
                                         </tr>
                                     }
@@ -263,7 +263,7 @@
                                     }
                                 </InputSelect>
                                 <label class="form-label">Attribute value:</label>
-                                <InputText @bind-Value=deviceUpdateAction.Value class="form-control"></InputText>
+                                <input type="text" @bind-value=deviceUpdateAction.Value class="form-control" @bind-value:event="oninput" />
                             }
                             else if (deviceUpdateAction.ActionType == DeviceUpdateActionType.AdministrativeUnit)
                             {
@@ -367,7 +367,8 @@
                             }
                             <br />
 
-                            <input type="submit" class="btn btn-primary mt-2 mb-3 @((string.IsNullOrEmpty(deviceUpdateAction.Name) && deviceUpdateAction.ActionType == DeviceUpdateActionType.Group) || (string.IsNullOrEmpty(deviceUpdateAction.Value) && deviceUpdateAction.ActionType == DeviceUpdateActionType.Attribute) || (string.IsNullOrEmpty(deviceUpdateAction.Name) && deviceUpdateAction.ActionType == DeviceUpdateActionType.AdministrativeUnit) ? "disabled" : "")" value="Add Action" />
+                            <input type="submit" class="btn btn-primary mt-2 mb-3 @(@validateActionInputs() ? "" : "disabled")" value="Add Action" />
+
                         </EditForm>
                 
 

--- a/DelegationStation/Pages/TagEdit.razor
+++ b/DelegationStation/Pages/TagEdit.razor
@@ -217,18 +217,18 @@
                                         </AuthorizeView>
                                     }
 
-                                    if (t == DeviceUpdateActionType.AdministrativeUnit)
+                                    if (t == DeviceUpdateActionType.Group)
                                     {
-                                        <AuthorizeView Context="TagAdministrativeUnitUpdateOption" Policy="TagUpdateActionAdministrativeUnits" Resource="_tag">
+                                        <AuthorizeView Context="TagGroupUpdateOption" Policy="TagUpdateActionSecurityGroups" Resource="_tag">
                                             <Authorized>
                                                 <option value="@t">@t</option>
                                             </Authorized>
                                         </AuthorizeView>
                                     }
 
-                                    if (t == DeviceUpdateActionType.Group)
+                                    if (t == DeviceUpdateActionType.AdministrativeUnit)
                                     {
-                                        <AuthorizeView Context="TagGroupUpdateOption" Policy="TagUpdateActionSecurityGroups" Resource="_tag">
+                                        <AuthorizeView Context="TagAdministrativeUnitUpdateOption" Policy="TagUpdateActionAdministrativeUnits" Resource="_tag">
                                             <Authorized>
                                                 <option value="@t">@t</option>
                                             </Authorized>

--- a/DelegationStation/Pages/TagEdit.razor
+++ b/DelegationStation/Pages/TagEdit.razor
@@ -187,7 +187,12 @@
                                             <td>@a.ActionType</td>
                                             <td>@a.Name</td>
                                             <td>@a.Value</td>
-                                            <td><button type="button" class="btn btn-danger @(ActionAllowed(a) ? "" : "disabled")" @onclick=@(ActionAllowed(a) ? (() => tag.UpdateActions.Remove(a)) : (() => {}))><span class="oi oi-trash"></span> Delete</button></td>
+                                            <td>
+                                            @if(ActionAllowed(a))
+                                            {
+                                              <button type="button" class="btn btn-danger @(ActionAllowed(a) ? "" : "disabled")" @onclick=@(ActionAllowed(a) ? (() => tag.UpdateActions.Remove(a)) : (() => {}))><span class="oi oi-trash"></span> Delete</button>
+                                            }
+                                            </td>
                                         </tr>
                                     }
                                 </tbody>

--- a/DelegationStation/Pages/TagEdit.razor.cs
+++ b/DelegationStation/Pages/TagEdit.razor.cs
@@ -946,13 +946,13 @@ namespace DelegationStation.Pages
             {
                 deviceUpdateAction.ActionType = DeviceUpdateActionType.Attribute;
             }
-            else if((await authorizationService.AuthorizeAsync(user, _tag, "TagUpdateActionAdministrativeUnits")).Succeeded)
-            {
-                deviceUpdateAction.ActionType = DeviceUpdateActionType.AdministrativeUnit;
-            }
             else if((await authorizationService.AuthorizeAsync(user, _tag, "TagUpdateActionSecurityGroups")).Succeeded)
             {
                 deviceUpdateAction.ActionType = DeviceUpdateActionType.Group;
+            }
+            else if((await authorizationService.AuthorizeAsync(user, _tag, "TagUpdateActionAdministrativeUnits")).Succeeded)
+            {
+                deviceUpdateAction.ActionType = DeviceUpdateActionType.AdministrativeUnit;
             }
         }
     }

--- a/DelegationStation/Pages/TagEdit.razor.cs
+++ b/DelegationStation/Pages/TagEdit.razor.cs
@@ -63,6 +63,7 @@ namespace DelegationStation.Pages
 
         private int deviceCount = 0;
 
+
         protected override async Task OnInitializedAsync()
         {
             deviceUpdateActionEditContext = new EditContext(deviceUpdateAction);
@@ -955,5 +956,24 @@ namespace DelegationStation.Pages
                 deviceUpdateAction.ActionType = DeviceUpdateActionType.AdministrativeUnit;
             }
         }
+
+        private bool validateActionInputs()
+        {
+            if(deviceUpdateAction.ActionType == DeviceUpdateActionType.Group)
+            {
+                return !(string.IsNullOrEmpty(deviceUpdateAction.Name));
+            }
+            else if (deviceUpdateAction.ActionType == DeviceUpdateActionType.Attribute)
+            {
+                return !(string.IsNullOrEmpty(deviceUpdateAction.Value) || string.IsNullOrEmpty(deviceUpdateAction.Name));
+            }
+            else if(deviceUpdateAction.ActionType == DeviceUpdateActionType.AdministrativeUnit)
+            {
+                return !(string.IsNullOrEmpty(deviceUpdateAction.Name));
+            }
+
+            return false;
+        }
+
     }
 }

--- a/DelegationStation/Pages/TagEdit.razor.cs
+++ b/DelegationStation/Pages/TagEdit.razor.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Graph.Models;
 
+
 namespace DelegationStation.Pages
 {
     public partial class TagEdit
@@ -83,6 +84,7 @@ namespace DelegationStation.Pages
                 await UpdateRoleDelegationGroups();
                 await GetRolesAsync();
             }
+            await SetInitialUpdateAction();
             deviceCount = await GetDeviceCount();
         }
 
@@ -936,6 +938,22 @@ namespace DelegationStation.Pages
         private void ConfirmDeleteTag()
         {
             ConfirmDelete?.Show();
+        }
+
+        private async Task SetInitialUpdateAction()
+        {
+            if((await authorizationService.AuthorizeAsync(user, _tag, "TagUpdateActionAttributes")).Succeeded)
+            {
+                deviceUpdateAction.ActionType = DeviceUpdateActionType.Attribute;
+            }
+            else if((await authorizationService.AuthorizeAsync(user, _tag, "TagUpdateActionAdministrativeUnits")).Succeeded)
+            {
+                deviceUpdateAction.ActionType = DeviceUpdateActionType.AdministrativeUnit;
+            }
+            else if((await authorizationService.AuthorizeAsync(user, _tag, "TagUpdateActionSecurityGroups")).Succeeded)
+            {
+                deviceUpdateAction.ActionType = DeviceUpdateActionType.Group;
+            }
         }
     }
 }

--- a/DelegationStation/Shared/NavMenu.razor
+++ b/DelegationStation/Shared/NavMenu.razor
@@ -24,11 +24,15 @@
                 <span class="oi oi-tags" aria-hidden="true"></span> Tags
             </NavLink>
         </div>
+<AuthorizeView Policy="DelegationStationAdmin">
+    <Authorized>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="Roles" Match="NavLinkMatch.Prefix">
                 <span class="oi oi-shield" aria-hidden="true"></span> Roles
             </NavLink>
         </div>
+        </Authorized>
+        </AuthorizeView>
     </nav>
 </div>
 

--- a/DelegationStationTests/Pages/NavMenuTests.cs
+++ b/DelegationStationTests/Pages/NavMenuTests.cs
@@ -1,0 +1,98 @@
+﻿using DelegationStation.Pages;
+using Microsoft.Extensions.DependencyInjection;
+using DelegationStation.Interfaces;
+using Microsoft.QualityTools.Testing.Fakes;
+using Microsoft.Extensions.Configuration;
+using Microsoft.AspNetCore.Http;
+using DelegationStation.Shared;
+
+namespace DelegationStationTests.Pages
+{
+    [TestClass]
+    public class NavMenuTests : Bunit.TestContext
+    {
+        [TestMethod]
+        public void DisplayRolesMenuToAdmins()
+        {
+            using (ShimsContext.Create())
+            {
+                // Arrange
+                Guid defaultId = Guid.NewGuid();
+                Guid userGroupId = Guid.NewGuid();
+                var authContext = this.AddTestAuthorization();
+                authContext.SetAuthorized("TEST USER");
+                authContext.SetClaims(new System.Security.Claims.Claim("name", "TEST USER"));
+                authContext.SetClaims(new System.Security.Claims.Claim("http://schemas.microsoft.com/ws/2008/06/identity/claims/role", defaultId.ToString()));
+                authContext.SetPolicies("DelegationStationAdmin");
+
+                var myConfiguration = new Dictionary<string, string>
+                {
+                    {"DefaultAdminGroupObjectId", defaultId.ToString()},
+                    {"Nested:Key1", "NestedValue1"},
+                    {"Nested:Key2", "NestedValue2"}
+                };
+
+                var configuration = new ConfigurationBuilder()
+                    .AddInMemoryCollection(myConfiguration)
+                    .Build();
+
+                var httpContext = new HttpContextAccessor();
+                httpContext.HttpContext = new DefaultHttpContext();
+
+                // Add Dependent Services
+                Services.AddSingleton<Microsoft.Extensions.Configuration.IConfiguration>(configuration);
+                Services.AddSingleton<IHttpContextAccessor>(httpContext);
+
+
+                // Act
+                var cut = RenderComponent<NavMenu>();
+
+                // Assert
+                Assert.IsTrue(cut.Markup.Contains("<a href=\"Roles\" class=\"nav-link\"><span class=\"oi oi-shield\" aria-hidden=\"true\" b-l9c7g71qbx></span> Roles\r\n            </a></div></nav></div>"), $"Role link should be rendered. \\nActual:\\n{cut.Markup}\"");
+
+
+            }
+        }
+
+        [TestMethod]
+        public void DoNotDisplayRolesMenuToNonAdmins()
+        {
+            using (ShimsContext.Create())
+            {
+                // Arrange
+                Guid defaultId = Guid.NewGuid();
+                Guid userGroupId = Guid.NewGuid();
+                var authContext = this.AddTestAuthorization();
+                authContext.SetAuthorized("TEST USER");
+                authContext.SetClaims(new System.Security.Claims.Claim("name", "TEST USER"));
+                authContext.SetClaims(new System.Security.Claims.Claim("http://schemas.microsoft.com/ws/2008/06/identity/claims/role", userGroupId.ToString()));
+
+                
+                var myConfiguration = new Dictionary<string, string>
+                {
+                    {"DefaultAdminGroupObjectId", defaultId.ToString()},
+                    {"Nested:Key1", "NestedValue1"},
+                    {"Nested:Key2", "NestedValue2"}
+                };
+
+                var configuration = new ConfigurationBuilder()
+                    .AddInMemoryCollection(myConfiguration)
+                    .Build();
+
+                var httpContext = new HttpContextAccessor();
+                httpContext.HttpContext = new DefaultHttpContext();
+
+                // Add Dependent Services
+                Services.AddSingleton<Microsoft.Extensions.Configuration.IConfiguration>(configuration);
+                Services.AddSingleton<IHttpContextAccessor>(httpContext);
+
+
+                // Act
+                var cut = RenderComponent<NavMenu>();
+
+                // Assert
+                Assert.IsFalse(cut.Markup.Contains("Roles"), $"Menu should not dispaly Roles link. \\nActual:\\n{cut.Markup}\"");
+            }
+        }
+    }
+}

--- a/DelegationStationTests/Pages/TagEditTests.cs
+++ b/DelegationStationTests/Pages/TagEditTests.cs
@@ -223,6 +223,34 @@ namespace DelegationStationTests.Pages
         }
 
         [TestMethod]
+        public void LimitedRoleShouldNotRenderAttributes()
+        {
+            using (ShimsContext.Create())
+            {
+                // Arrange
+                // Add Dependent Services
+                Guid defaultId = Guid.NewGuid();
+                Guid userGroup = Guid.NewGuid();
+                var authContext = this.AddTestAuthorization();
+                authContext.SetAuthorized("TEST USER");
+                authContext.SetClaims(new System.Security.Claims.Claim("name", "TEST USER"));
+                authContext.SetClaims(new System.Security.Claims.Claim("http://schemas.microsoft.com/ws/2008/06/identity/claims/role", userGroup.ToString()));
+                authContext.SetClaims(new System.Security.Claims.Claim("roles", userGroup.ToString()));
+                authContext.SetPolicies("TagView");
+
+                AddLimitedRoleServices(defaultId.ToString(), userGroup.ToString());
+
+                // Act
+                var cut = RenderComponent<TagEdit>(parameters => parameters
+                    .Add(p => p.Id, "myId"));
+
+                // Assert
+                string match = $"<option value=\"Attribute\".*>Attribute</option>";
+                Assert.IsFalse(Regex.IsMatch(cut.Markup, match), $"Expected Match:\n{match}\nActual:\n{cut.Markup}");
+            }
+        }
+
+        [TestMethod]
         public void UnauthorizedShouldNotRender()
         {
             using (ShimsContext.Create())


### PR DESCRIPTION
Navigation Menu:  
- Now only displays Roles link to Admin users.

Tag Edit page:  

-   Updated Action display to only show delete button when user has permissions to delete (vs  just disabling).
-   Fixed bug for non-admin users that would prevent them from searching (and thus selecting) groups/AUs they had permission to edit.
-  Fixed bug with enablement of Add button for extension attributes that would make it appear like you had to click it twice to add.
-  Added functionality to not enable Add button for extension attributes before user had selected which attribute.

Test Cases:

- Added test case for new Nav Menu update.
- Added missing test case for ensuring users without permissions cannot edit attributes.