### PR TITLE
Update software to support managed-identity based authentication to CosmosDB

### DIFF
--- a/DelegationStation/Services/DeviceDBService.cs
+++ b/DelegationStation/Services/DeviceDBService.cs
@@ -1,10 +1,12 @@
+using Azure.Core;
 using DelegationStation.Interfaces;
 using DelegationStationShared.Models;
 using Microsoft.Azure.Cosmos;
+using Azure.Identity;
 
 namespace DelegationStation.Services
 {
- 
+
     public class DeviceDBService : IDeviceDBService
     {
         private readonly ILogger<DeviceDBService> _logger;
@@ -18,9 +20,10 @@ namespace DelegationStation.Services
             {
                 throw new Exception("DeviceDBService appsettings configuration is null.");
             }
-            if (string.IsNullOrEmpty(configuration.GetSection("COSMOS_CONNECTION_STRING").Value))
+            if (string.IsNullOrEmpty(configuration.GetSection("COSMOS_CONNECTION_STRING").Value) &&
+                string.IsNullOrEmpty(configuration.GetSection("COSMOS_ENDPOINT").Value))
             {
-                throw new Exception("DeviceDBService appsettings COSMOS_CONNECTION_STRING is null or empty");
+                throw new Exception("DeviceDBService appsettings COSMOS_CONNECTION_STRING and COSMOS_ENDPOINT settings are both null or empty. At least one must be set.");
             }
             if (string.IsNullOrEmpty(configuration.GetSection("DefaultAdminGroupObjectId").Value))
             {
@@ -35,12 +38,25 @@ namespace DelegationStation.Services
                 _logger.LogInformation("COSMOS_CONTAINER_NAME is null or empty, using default value of DeviceData");
             }
 
+            string cosmosEndpoint = configuration.GetSection("COSMOS_ENDPOINT").Value;
+            string cosmosConnectionString = configuration.GetSection("COSMOS_CONNECTION_STRING").Value;
             string dbName = string.IsNullOrEmpty(configuration.GetSection("COSMOS_DATABASE_NAME").Value) ? "DelegationStationData" : configuration.GetSection("COSMOS_DATABASE_NAME").Value!;
             string containerName = string.IsNullOrEmpty(configuration.GetSection("COSMOS_CONTAINER_NAME").Value) ? "DeviceData" : configuration.GetSection("COSMOS_CONTAINER_NAME").Value!;
 
-            CosmosClient client = new(
-                connectionString: configuration.GetSection("COSMOS_CONNECTION_STRING").Value!
-            );
+            CosmosClient client;
+            if (!string.IsNullOrEmpty(cosmosEndpoint))
+            {
+                logger.LogInformation("Using Managed Identity to connect to CosmosDB");
+                TokenCredential credential = new ManagedIdentityCredential();
+                client = new CosmosClient(cosmosEndpoint, credential);
+            }
+            else
+            {
+                logger.LogInformation("Using Connection String to connect to CosmosDB");
+                client = new(
+                    connectionString: configuration.GetSection("COSMOS_CONNECTION_STRING").Value!
+                );
+            }
             ConfigureCosmosDatabase(client, dbName, containerName);
             this._container = client.GetContainer(dbName, containerName);
             _DefaultGroup = configuration.GetSection("DefaultAdminGroupObjectId").Value;

--- a/DelegationStation/Services/DeviceTagDBService.cs
+++ b/DelegationStation/Services/DeviceTagDBService.cs
@@ -1,3 +1,5 @@
+using Azure.Core;
+using Azure.Identity;
 using DelegationStation.Interfaces;
 using DelegationStationShared.Models;
 using Microsoft.Azure.Cosmos;
@@ -17,9 +19,10 @@ namespace DelegationStation.Services
             {
                 throw new Exception("DeviceDBService appsettings configuration is null.");
             }
-            if (string.IsNullOrEmpty(configuration.GetSection("COSMOS_CONNECTION_STRING").Value))
+            if (string.IsNullOrEmpty(configuration.GetSection("COSMOS_CONNECTION_STRING").Value) &&
+               string.IsNullOrEmpty(configuration.GetSection("COSMOS_ENDPOINT").Value))
             {
-                throw new Exception("DeviceDBService appsettings COSMOS_CONNECTION_STRING is null or empty");
+                throw new Exception("DeviceDBService appsettings COSMOS_CONNECTION_STRING and COSMOS_ENDPOINT settings are both null or empty. At least one must be set.");
             }
             if (string.IsNullOrEmpty(configuration.GetSection("DefaultAdminGroupObjectId").Value))
             {
@@ -34,13 +37,26 @@ namespace DelegationStation.Services
                 _logger.LogInformation("COSMOS_CONTAINER_NAME is null or empty, using default value of DeviceData");
             }
 
+            string cosmosEndpoint = configuration.GetSection("COSMOS_ENDPOINT").Value;
+            string cosmosConnectionString = configuration.GetSection("COSMOS_CONNECTION_STRING").Value;
             string dbName = string.IsNullOrEmpty(configuration.GetSection("COSMOS_DATABASE_NAME").Value) ? "DelegationStationData" : configuration.GetSection("COSMOS_DATABASE_NAME").Value!;
             string containerName = string.IsNullOrEmpty(configuration.GetSection("COSMOS_CONTAINER_NAME").Value) ? "DeviceData" : configuration.GetSection("COSMOS_CONTAINER_NAME").Value!;
 
 
-            CosmosClient client = new(
-                connectionString: configuration.GetSection("COSMOS_CONNECTION_STRING").Value!
-            );
+            CosmosClient client;
+            if (!string.IsNullOrEmpty(cosmosEndpoint))
+            {
+                logger.LogInformation("Using Managed Identity to connect to CosmosDB");
+                TokenCredential credential = new ManagedIdentityCredential();
+                client = new CosmosClient(cosmosEndpoint, credential);
+            }
+            else
+            {
+                logger.LogInformation("Using Connection String to connect to CosmosDB");
+                client = new(
+                    connectionString: configuration.GetSection("COSMOS_CONNECTION_STRING").Value!
+                );
+            }
             ConfigureCosmosDatabase(client, dbName, containerName);
             this._container = client.GetContainer(dbName, containerName);
             _DefaultGroup = configuration.GetSection("DefaultAdminGroupObjectId").Value;

--- a/UpdateDevices/Services/CosmosDbService.cs
+++ b/UpdateDevices/Services/CosmosDbService.cs
@@ -1,4 +1,6 @@
-﻿using DelegationStationShared;
+﻿using Azure.Core;
+using Azure.Identity;
+using DelegationStationShared;
 using DelegationStationShared.Extensions;
 using DelegationStationShared.Models;
 using Microsoft.Azure.Cosmos;
@@ -29,6 +31,10 @@ namespace UpdateDevices.Services
       string containerName = Environment.GetEnvironmentVariable("COSMOS_CONTAINER_NAME", EnvironmentVariableTarget.Process);
       string databaseName = Environment.GetEnvironmentVariable("COSMOS_DATABASE_NAME", EnvironmentVariableTarget.Process);
       var connectionString = Environment.GetEnvironmentVariable("COSMOS_CONNECTION_STRING", EnvironmentVariableTarget.Process);
+      bool managedIdAuthEnabled = false;
+      bool.TryParse(Environment.GetEnvironmentVariable("CosmosManagedIdAuthEnabled", EnvironmentVariableTarget.Process), out managedIdAuthEnabled);
+      string cosmosEndpoint = Environment.GetEnvironmentVariable("COSMOS_ENDPOINT", EnvironmentVariableTarget.Process);
+
 
       if (string.IsNullOrEmpty(containerName))
       {
@@ -40,17 +46,31 @@ namespace UpdateDevices.Services
         _logger.DSLogWarning("COSMOS_DATABASE_NAME is null or empty, using default value of DelegationStationData", fullMethodName);
         databaseName = "DelegationStationData";
       }
-      if (String.IsNullOrEmpty(connectionString))
+      if (!managedIdAuthEnabled && String.IsNullOrEmpty(connectionString))
       {
         _logger.DSLogError("Cannot connect to CosmosDB. Missing required environment variable COSMOS_CONNECTION_STRING", fullMethodName);
         return;
       }
+      if (managedIdAuthEnabled && String.IsNullOrEmpty(cosmosEndpoint))
+      {
+        _logger.DSLogError("Cannot connect to CosmosDB. Missing required environment variable COSMOS_ENDPOINT", fullMethodName);
+        return;
+      }
+
 
       try
       {
         if (_cosmosClient == null)
         {
-          _cosmosClient = new CosmosClient(connectionString);
+          if (managedIdAuthEnabled)
+          {
+            TokenCredential credential = new ManagedIdentityCredential();
+            _cosmosClient = new CosmosClient(cosmosEndpoint, credential);
+          }
+          else
+          {
+            _cosmosClient = new CosmosClient(connectionString);
+          }
           _container = _cosmosClient.GetContainer(databaseName, containerName);
         }
         else if (_container == null)
@@ -269,7 +289,7 @@ namespace UpdateDevices.Services
             return results;
         }
 
-        // Removes entries that were enrolled over a day ago and have less than the max number 
+        // Removes entries that were enrolled over a day ago and have less than the max number
         // retries indicating UpdateDevices was able to process them before it stopped retrying
         public async Task<List<Straggler>> GetStragglersProcessedByUD(int minCount)
         {

--- a/scripts/disableCosmosMI.sh.template
+++ b/scripts/disableCosmosMI.sh.template
@@ -1,0 +1,20 @@
+#! /bin/bash
+
+# SET THE VALUES BELOW
+rg="<DS RESOURCE GROUP>"
+name="<COSMOSDB NAME>"
+
+
+#
+# Disable key-based access
+#
+echo -n "Disabling local auth on CosmosDB..."
+az resource update --resource-group $rg --name $name --resource-type "Microsoft.DocumentDB/databaseAccounts" --set properties.disableLocalAuth=false -o none
+echo "Done."
+
+#
+# Output resultant setting
+# 
+az resource show --resource-group $rg --name $name --resource-type "Microsoft.DocumentDB/databaseAccounts" --query "properties.{disableLocalAuth:disableLocalAuth}"
+
+

--- a/scripts/enableCosmosMI.sh.template
+++ b/scripts/enableCosmosMI.sh.template
@@ -1,0 +1,91 @@
+#! /bin/bash
+
+
+# SET THE VALUES BELOW
+rg="<DS RESOURCE GROUP NAME>"
+name="<COSMOS DB NAME>"
+
+updateDS_name="<UPDATE FUNCTION NAME>"
+corpIDsync_name="<CORPID SYNC FUNCTION NAME>"
+webapp_name="<WEBAPP NAME>"
+
+#
+# Added to so git bash doesn't fill in path in front of parameters
+#
+export MSYS_NO_PATHCONV=1
+
+
+#
+# Disable key-based access
+#
+
+echo -n "Disabling key-based authentication..."
+#az resource update --resource-group $rg --name $name --resource-type "Microsoft.DocumentDB/databaseAccounts" --set properties.disableLocalAuth=true -o none
+echo "Done"
+
+#
+# Output resultant setting
+#
+
+az resource show --resource-group $rg --name $name --resource-type "Microsoft.DocumentDB/databaseAccounts" --query "properties.{disableLocalAuth:disableLocalAuth}"
+
+
+#
+# Get necessary IDs
+# 
+
+user_id=`az ad signed-in-user show --query id | tr -d '"'`
+#echo "user_id: $user_id"
+
+cosmos_id=`az cosmosdb show --resource-group $rg --name $name --query "{id:id}" | jq '.id' | tr -d '"'`
+#echo "cosmos_id: $cosmos_id"
+updateFunction_id=`az functionapp show --resource-group $rg --name $updateDS_name --query "{id:id}" | jq '.id' | tr -d '"'`
+#echo "updateFunction_id: $updateFunction_id"
+corpIDSync_id=`az functionapp show --resource-group $rg --name $corpIDsync_name --query "{id:id}" | jq '.id' | tr -d '"'`
+#echo "corpIDSync_id: $corpIDSync_id"
+webapp_id=`az webapp show --resource-group $rg --name $webapp_name --query "{id:id}" | jq '.id' | tr -d '"'`
+#echo "webapp_id: $webapp_id"
+
+reader_role=`az cosmosdb sql role definition list -g $rg --account-name $name --query "[?contains(roleName,'Reader')].{id:id}" | jq '.[].id' | tr -d '"' | awk -F '/' '{print $11}'`
+#echo "reader_role: $reader_role"
+contributor_role=`az cosmosdb sql role definition list -g $rg --account-name $name --query "[?contains(roleName,'Contributor')].{id:id}" | jq '.[].id' | tr -d '"' | awk -F '/' '{print $11}'`
+#echo "contributor_role: $contributor_role"
+
+
+
+# TODO:  Need to make it smarter so it doesn't add dupes
+
+#
+# Grant current user access to Azure Portal
+#
+echo "Assigning roles to current user..."
+az cosmosdb sql role assignment create --resource-group $rg --account-name $name --role-definition-id "$reader_role" --principal-id $user_id --scope $cosmos_id -o none
+az cosmosdb sql role assignment create --resource-group $rg --account-name $name --role-definition-id "$contributor_role" --principal-id $user_id --scope $cosmos_id -o none
+echo "Done"
+
+
+#
+# Grant Azure Functions/Web App access to DB
+# 
+
+echo "Assigning roles to current user..."
+az cosmosdb sql role assignment create --resource-group $rg --account-name $name --role-definition-id "$reader_role" --principal-id $user_id --scope $cosmos_id -o none
+az cosmosdb sql role assignment create --resource-group $rg --account-name $name --role-definition-id $contributor_role --principal-id $user_id --scope $cosmos_id -o none
+echo "Done"
+
+echo "Assigning roles to current user..."
+az cosmosdb sql role assignment create --resource-group $rg --account-name $name --role-definition-id "$reader_role" --principal-id $user_id --scope $cosmos_id -o none
+az cosmosdb sql role assignment create --resource-group $rg --account-name $name --role-definition-id $contributor_role --principal-id $user_id --scope $cosmos_id -o none
+echo "Done"
+
+echo "Assigning roles to current user..."
+az cosmosdb sql role assignment create --resource-group $rg --account-name $name --role-definition-id "$reader_role" --principal-id $user_id --scope $cosmos_id -o none
+az cosmosdb sql role assignment create --resource-group $rg --account-name $name --role-definition-id $contributor_role --principal-id $user_id --scope $cosmos_id -o none
+echo "Done"
+
+#
+# Output resultant role assignments
+#
+
+az cosmosdb sql role assignment list -g $rg --account-name $name --query "sort_by([].{principalId:principalId,roleDefinitionId:roleDefinitionId},&principalId)"
+


### PR DESCRIPTION
Added new COSMOS_ENDPOINT setting for software.
When present, applications will default to using managed-identity based authentication.
When not present, it will continue to using Connection String with key-based authentication.

Local development requires use of CosmosDB Emulator which is only compatible with connection-string.
This also means we can continue to support Azure deployments with connection string as necessary.

Solution includes two script templates for updating your Azure Deployment with the required settings.


