### PR TITLE
Fixing bug where "None" is a possible attribute in Role Edit screen

### DIFF
--- a/DelegationStation/Pages/RoleEdit.razor
+++ b/DelegationStation/Pages/RoleEdit.razor
@@ -32,7 +32,8 @@
                     @{
                         foreach (var attr in Enum.GetValues(typeof(AllowedAttributes)))
                         {
-                            if ((AllowedAttributes)attr == AllowedAttributes.All)
+                            if ((AllowedAttributes)attr == AllowedAttributes.All ||
+                            (AllowedAttributes)attr == AllowedAttributes.None)
                             {
                                 continue;
                             }


### PR DESCRIPTION
Old bug.  Added a value of None to Enum to fix another issue and missed that it was listed as an eligible attribute on the Role Edit page. 

Confirmed it wasn't accidentally assigned to any of the Roles in PROD.