### PR TITLE
Bulk Update:  Adding trim to add/remove column 

### DIFF
--- a/DelegationStation/Pages/DevicesBulkAction.razor.cs
+++ b/DelegationStation/Pages/DevicesBulkAction.razor.cs
@@ -175,7 +175,7 @@ namespace DelegationStation.Pages
                             try
                             {
                                 // Validate Make, Model, SerialNumber, Action
-                                if (input[3].ToLower() != "add" && input[3].ToLower() != "remove")
+                                if (input[3].ToLower().Trim() != "add" && input[3].ToLower().Trim() != "remove")
                                 {
                                     var message = $"File upload error.\nFile Name: {file.Name}\nInvalid action. Action should be either add or remove.\nCorrelation Id: {c.ToString()}";
                                     fileError.Add(message);


### PR DESCRIPTION
A life improvement request from the users.  
Ignores any leading/trailing whitespace that makes it into the add/remove column of bulk upload spreadsheets.