### PR TITLE
Update validation string for Make/Model to allow commas

### DIFF
--- a/DelegationSharedLibrary/Models/Device.cs
+++ b/DelegationSharedLibrary/Models/Device.cs
@@ -10,12 +10,12 @@ namespace DelegationStationShared.Models
         public Guid Id { get; set; }
 
         [Required(AllowEmptyStrings = false, ErrorMessage = "Make is Required")]
-        [RegularExpression(@"^[a-zA-Z0-9\-_.&\(\)\s]+$", ErrorMessage = "Only use letters, numbers, -, _, &, (, ) or . for Make value.")]
+        [RegularExpression(@"^[a-zA-Z0-9\-_.,&\(\)\s]+$", ErrorMessage = "Only use letters, numbers, or the following special characters: -_&().,")]
         public string Make { get; set; }
 
         [Required(AllowEmptyStrings = false, ErrorMessage = "Model is Required")]
 
-        [RegularExpression(@"^[a-zA-Z0-9\-_.&\(\)+\s]+$", ErrorMessage = "Use letters, numbers, -, _, &, (, ), + or . for Model value.")]
+        [RegularExpression(@"^[a-zA-Z0-9\-_.,&\(\)\s]+$", ErrorMessage = "Only use letters, numbers, or the following special characters: -_&().,")]
         public string Model { get; set; }
 
 

--- a/DelegationSharedLibrary/Models/DeviceBulk.cs
+++ b/DelegationSharedLibrary/Models/DeviceBulk.cs
@@ -6,12 +6,12 @@ namespace DelegationStationShared.Models
     public class DeviceBulk
     {
         [Required(AllowEmptyStrings = false)]
-        [RegularExpression(@"^[a-zA-Z0-9\-_.&\(\)\s]+$", ErrorMessage = "Use letters, numbers, -, _, &, (, ) or . for Make value.")]
+        [RegularExpression(@"^[a-zA-Z0-9\-_.,&\(\)\s]+$", ErrorMessage = "For make, only use letters, numbers, or the following special characters: -_&().,")]
         public string Make { get; set; }
 
         [Required(AllowEmptyStrings = false)]
-        [RegularExpression(@"^[a-zA-Z0-9\-_.&\(\)+\s]+$", ErrorMessage = "Use letters, numbers, -, _, &, (, ), + or . for Model value.")]
 
+        [RegularExpression(@"^[a-zA-Z0-9\-_.,&\(\)\s]+$", ErrorMessage = "For model, only use letters, numbers, or the following special characters: -_&().,")]
         public string Model { get; set; }
 
 


### PR DESCRIPTION
Field reported having some (Panisconic?) devices with commas in Make/Model.  

Updated validation strings to allow entering commas via device screen and bulk upload.

Verified previous fixes done to handle commas still work, so no additional coding changes are needed.

