### PR TITLE
Update batch size for add device function

### DIFF
--- a/CorporateIdentifierSyncs/AddNewDevices.cs
+++ b/CorporateIdentifierSyncs/AddNewDevices.cs
@@ -73,6 +73,7 @@ namespace CorporateIdentifierSync
 
             // For each device set blank Corporate Identifier values
             int deviceCount = 0;
+            int totalDevices = devicesToMigrate.Count;
             foreach (Device device in devicesToMigrate)
             {
 
@@ -138,7 +139,7 @@ namespace CorporateIdentifierSync
                     await _dbService.UpdateDevice(device);
                     deviceCount++;
 
-                    _logger.DSLogInformation($"Successfully added Corporate Identifier for device {device.Make} {device.Model} {device.SerialNumber}.", fullMethodName);
+                    _logger.DSLogInformation($"Successfully added Corporate Identifier for device {deviceCount}/{totalDevices}:  {device.Make} {device.Model} {device.SerialNumber}.", fullMethodName);
                 }
                 catch (Exception ex)
                 {

--- a/CorporateIdentifierSyncs/AddNewDevices.cs
+++ b/CorporateIdentifierSyncs/AddNewDevices.cs
@@ -55,13 +55,26 @@ namespace CorporateIdentifierSync
                 return;
             }
 
+            int batchSize = 5000;
+            string batchSizeString = Environment.GetEnvironmentVariable("AddDeviceBatchSize", EnvironmentVariableTarget.Process);
+            if (!int.TryParse(batchSizeString, out int bs) || bs <= 0)
+            {
+                _logger.DSLogError($"BatchSize is not set or invalid. Using default value: {batchSize}.", fullMethodName);
+            }
+            else
+            {
+                batchSize = bs;
+                _logger.DSLogInformation($"Using BatchSize: {batchSize}.", fullMethodName);
+            }
+
+
 
 
             // Get All Devices without Corporate Identifier values or fields
             List<Device> devicesToMigrate = new List<Device>();
             try
             {
-                devicesToMigrate = await _dbService.GetAddedDevices();
+                devicesToMigrate = await _dbService.GetAddedDevices(batchSize);
                 _logger.DSLogInformation($"Found {devicesToMigrate.Count} devices to migrate.", fullMethodName);
             }
             catch (Exception ex)

--- a/CorporateIdentifierSyncs/Interfaces/ICosmosDbService.cs
+++ b/CorporateIdentifierSyncs/Interfaces/ICosmosDbService.cs
@@ -4,7 +4,7 @@ namespace CorporateIdentifierSync.Interfaces
 {
     public interface ICosmosDbService
     {
-        Task<List<Device>> GetAddedDevices();
+        Task<List<Device>> GetAddedDevices(int batchSize);
 
         Task<List<Device>> GetDevicesMarkedForDeletion();
 

--- a/CorporateIdentifierSyncs/Services/CosmosDbService.cs
+++ b/CorporateIdentifierSyncs/Services/CosmosDbService.cs
@@ -86,10 +86,11 @@ namespace CorporateIdentifierSync.Services
             string fullMethodName = className + "." + methodName;
 
             // To ensure previously added devices are processed, check for devices without status as well as those set to Added
-            // to handle initially large number of devices and our large bulk uploads, limiting processing to 10K devices at a time
+            // to handle initially large number of devices and our large bulk uploads, limiting processing to 40K devices at a time
+            // TODO
             QueryDefinition query = new QueryDefinition("SELECT * FROM c WHERE c.Type = \"Device\" " +
-                "AND (NOT IS_DEFINED(c.Status) OR (c.Status = @status)) " +
-                "OFFSET 0 LIMIT 10000");
+                "AND (NOT IS_DEFINED(c.Status) OR (c.Status = @status)) ORDER BY c.ModifiedUTC DESC " +
+                "OFFSET 0 LIMIT 5000");
             query.WithParameter("@status", DeviceStatus.Added);
 
             var queryIterator = _container.GetItemQueryIterator<Device>(query);

--- a/CorporateIdentifierSyncs/Services/CosmosDbService.cs
+++ b/CorporateIdentifierSyncs/Services/CosmosDbService.cs
@@ -79,19 +79,22 @@ namespace CorporateIdentifierSync.Services
 
 
 
-        public async Task<List<Device>> GetAddedDevices()
+        public async Task<List<Device>> GetAddedDevices(int batchSize)
         {
             string methodName = ExtensionHelper.GetMethodName() ?? "";
             string className = GetType().Name;
             string fullMethodName = className + "." + methodName;
+
+            _logger.DSLogInformation($"Getting next {batchSize} devices with status Added.", fullMethodName);
 
             // To ensure previously added devices are processed, check for devices without status as well as those set to Added
             // to handle initially large number of devices and our large bulk uploads, limiting processing to 40K devices at a time
             // TODO
             QueryDefinition query = new QueryDefinition("SELECT * FROM c WHERE c.Type = \"Device\" " +
                 "AND (NOT IS_DEFINED(c.Status) OR (c.Status = @status)) ORDER BY c.ModifiedUTC DESC " +
-                "OFFSET 0 LIMIT 5000");
+                "OFFSET 0 LIMIT @batchSize");
             query.WithParameter("@status", DeviceStatus.Added);
+            query.WithParameter("@batchSize", batchSize);
 
             var queryIterator = _container.GetItemQueryIterator<Device>(query);
 

--- a/DelegationStation/Services/DeviceTagDBService.cs
+++ b/DelegationStation/Services/DeviceTagDBService.cs
@@ -2,6 +2,7 @@ using Azure.Core;
 using Azure.Identity;
 using DelegationStation.Interfaces;
 using DelegationStationShared.Models;
+using DelegationStationShared;
 using Microsoft.Azure.Cosmos;
 
 namespace DelegationStation.Services
@@ -249,7 +250,7 @@ namespace DelegationStation.Services
                 throw new Exception("DeviceDBService GetDeviceAsync was sent null tagId");
             }
 
-            if (!System.Text.RegularExpressions.Regex.Match(tagId, "^([0-9A-Fa-f]{8}[-]?[0-9A-Fa-f]{4}[-]?[0-9A-Fa-f]{4}[-]?[0-9A-Fa-f]{4}[-]?[0-9A-Fa-f]{12})$").Success)
+            if (!System.Text.RegularExpressions.Regex.Match(tagId,DSConstants.GUID_REGEX).Success)
             {
                 throw new Exception($"DeviceDBService GetDeviceAsync tagId did not match GUID format {tagId}");
             }
@@ -259,7 +260,7 @@ namespace DelegationStation.Services
         }
 
 
-       
+
 
         public async Task<int> GetDeviceCountByTagIdAsync(string tagId)
         {

--- a/README.md
+++ b/README.md
@@ -496,6 +496,10 @@ For example, "https://graph.microsoft.com/"
 <b>"SyncIntervalHours":  "4"</b><br/>
 Amount of time to pass before checking that a device is still synced.  For example, "4" will pull all devices with a sync time older than Now-4 hours.
 
+<b>"AddDeviceBatchSize": "5000"</b><br/>
+(Optional) Amount of devices the AddDevices function will attempt to add in a single batch.  Default is 5000, which is estimated to run 15 minutes, but can be set lower if you are having issues with the function timing out.
+
+
 #### Certificate Configuration
 
 This is only needed if you are connecting to Graph using certificates.


### PR DESCRIPTION
Based on development testing, it takes not quite 15 minutes to process 5000 device entries.  
This assumes all of the hosts will get added into Corporate Identifiers.  It is faster if we're just updating the CosmosDB.