### PR TITLE
Fix search button alignment

### DIFF
--- a/DelegationStation/Pages/Devices.razor
+++ b/DelegationStation/Pages/Devices.razor
@@ -53,7 +53,7 @@
                                             default:
                                                 result = result + status.Key.ToString() + ": No Description Available" + "<div/>";
                                                 break;
-                                        
+
                                         }
                                     }
                                     result = result + "</span>";
@@ -91,7 +91,7 @@
                                     </td>
                                     <td></td>
                                     <td></td>
-                                    <td>
+                                    <td align="center">
                                         <button type="button" class="btn btn-primary" @onclick=@(() => GetDevicesSearch())>Search</button>
                                     </td>
                                 </tr>


### PR DESCRIPTION
On bigger screens, the search button isn't in alignment with Delete buttons below.
Added align="Center" to table data tag to resolve.