### PR TITLE
Fixing bug where ConfirmSync wasn't able to add CorpID if tag changed

### DIFF
--- a/CorporateIdentifierSyncs/AddNewDevices.cs
+++ b/CorporateIdentifierSyncs/AddNewDevices.cs
@@ -116,11 +116,11 @@ namespace CorporateIdentifierSync
                 {
                     if (isCorpIDSyncEnabledForTag)
                     {
+                        _logger.DSLogInformation($"-----Adding Corporate Identifier for device {device.Make} {device.Model} {device.SerialNumber}.-----", fullMethodName);
+
                         string identifier = "";
                         if ((device.OS == DeviceOS.Windows) || (device.OS == DeviceOS.Unknown))
                         {
-                            device.CorporateIdentityType = ImportedDeviceIdentityType.ManufacturerModelSerial;
-                            _logger.DSLogInformation($"-----Adding Corporate Identifier for device {device.Make} {device.Model} {device.SerialNumber}.-----", fullMethodName);
 
                             // Putting make and model in quotes to handle commas
                             string escapedMake = "\"" + device.Make + "\"";
@@ -129,10 +129,11 @@ namespace CorporateIdentifierSync
                         }
                         else
                         {
-                            device.CorporateIdentityType = ImportedDeviceIdentityType.SerialNumber;
                             identifier = device.SerialNumber;
                         }
-                        ImportedDeviceIdentity deviceIdentity = await _graphBetaService.AddCorporateIdentifier(device.CorporateIdentityType, identifier);
+
+                        ImportedDeviceIdentityType corpIDType = CorpIDUtilities.GetCorpIDTypeForOS(device.OS);
+                        ImportedDeviceIdentity deviceIdentity = await _graphBetaService.AddCorporateIdentifier(corpIDType, identifier);
 
                         // Set the Corporate Identifier values
                         device.CorporateIdentityID = deviceIdentity.Id;

--- a/CorporateIdentifierSyncs/ConfirmSync.cs
+++ b/CorporateIdentifierSyncs/ConfirmSync.cs
@@ -98,22 +98,27 @@ namespace CorporateIdentifierSync
                         if ((device.OS == DeviceOS.Windows) || (device.OS == DeviceOS.Unknown))
                         {
                             identifier = $"{device.Make},{device.Model},{device.SerialNumber}";
+
                         }
                         else
                         {
                             identifier = device.SerialNumber;
                         }
-                            try
-                            {
-                                ImportedDeviceIdentity deviceIdentity = await _graphBetaService.AddCorporateIdentifier(device.CorporateIdentityType, identifier);
-                                device.CorporateIdentityID = deviceIdentity.Id;
-                                device.CorporateIdentity = deviceIdentity.ImportedDeviceIdentifier;
-                                corpIDUpdated = true;
-                            }
-                            catch (Exception ex)
-                            {
-                                _logger.DSLogError($"Error adding corporate identifier for device {device.Id}: {ex.Message}", fullMethodName);
-                            }
+
+
+                        try
+                        {
+                            ImportedDeviceIdentityType corpIDType = CorpIDUtilities.GetCorpIDTypeForOS(device.OS);
+                            ImportedDeviceIdentity deviceIdentity = await _graphBetaService.AddCorporateIdentifier(corpIDType, identifier);
+
+                            device.CorporateIdentityID = deviceIdentity.Id;
+                            device.CorporateIdentity = deviceIdentity.ImportedDeviceIdentifier;
+                            corpIDUpdated = true;
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.DSLogError($"Error adding corporate identifier for device {device.Id}: {ex.Message}", fullMethodName);
+                        }
 
                     }
                     else
@@ -152,7 +157,7 @@ namespace CorporateIdentifierSync
                     }
                 }
 
-                if((!tagSetToSync && successfullyUnsynced) || corpIDFound || corpIDUpdated)
+                if ((!tagSetToSync && successfullyUnsynced) || corpIDFound || corpIDUpdated)
                 {
 
                     // Update the sync date and status for devices successfully processed

--- a/CorporateIdentifierSyncs/CorpIDUtilities.cs
+++ b/CorporateIdentifierSyncs/CorpIDUtilities.cs
@@ -1,0 +1,27 @@
+﻿using DelegationStationShared.Enums;
+using Microsoft.Graph.Beta.Models;
+
+namespace CorporateIdentifierSync
+{
+    internal static class CorpIDUtilities
+    {
+        public static ImportedDeviceIdentityType GetCorpIDTypeForOS(DeviceOS? os)
+        {
+            switch (os)
+            {
+                case DeviceOS.Windows:
+                case DeviceOS.Unknown:
+                    //treat Unknown as Windows for Corporate Identifier purposes
+                    return ImportedDeviceIdentityType.ManufacturerModelSerial;
+                case DeviceOS.MacOS:
+                case DeviceOS.iOS:
+                case DeviceOS.Android:
+                    return ImportedDeviceIdentityType.SerialNumber;
+                default:
+                    // We are in trouble if we get here....
+                    throw new ArgumentException($"Unsupported OS type: {os}");
+            }
+        }
+
+    }
+}

--- a/DelegationSharedLibrary/Models/Device.cs
+++ b/DelegationSharedLibrary/Models/Device.cs
@@ -43,8 +43,6 @@ namespace DelegationStationShared.Models
 
         // Corporate Identifier related
         public string CorporateIdentity { get; set; }
-        //public string CorporateIdentityType { get; set; }
-        public ImportedDeviceIdentityType  CorporateIdentityType { get; set; }
         public DateTime LastCorpIdentitySync { get; set; }
         public string CorporateIdentityID { get; set; }
 


### PR DESCRIPTION
Removed CorporateIdentityType from Device DB object since we can determine it from DeviceOS.
Added utility to return value given deviceOS that is now called immediatly prior to calling the method to add the CorporateIdentifier.
Also moved a log entry to a more logical place.