### PR TITLE
Removing "unenroll" from device deletion confirmation window

### DIFF
--- a/DelegationStation/Pages/Devices.razor.cs
+++ b/DelegationStation/Pages/Devices.razor.cs
@@ -248,7 +248,8 @@ namespace DelegationStation.Pages
 
         private void Show()
         {
-            confirmMessage = (MarkupString)$"<b>This will mark the device to be unenrolled and deleted from Corporate Identifiers and Delegation Station: </b></br></br><b>Make:</b> {deleteDevice.Make}<br /><b>Model:</b> {deleteDevice.Model}<br /><b>Serial Number:</b> {deleteDevice.SerialNumber}</br></br><b>Confirm you want to <u>unenroll</u> and <u>delete</u> this device:</b><br />";
+            // confirmMessage = (MarkupString)$"<b>This will mark the device to be unenrolled and deleted from Corporate Identifiers and Delegation Station: </b></br></br><b>Make:</b> {deleteDevice.Make}<br /><b>Model:</b> {deleteDevice.Model}<br /><b>Serial Number:</b> {deleteDevice.SerialNumber}</br></br><b>Confirm you want to <u>unenroll</u> and <u>delete</u> this device:</b><br />";
+            confirmMessage = (MarkupString)$"<b>This will mark the device to be deleted from both Corporate Identifiers and Delegation Station: </b></br></br><b>Make:</b> {deleteDevice.Make}<br /><b>Model:</b> {deleteDevice.Model}<br /><b>Serial Number:</b> {deleteDevice.SerialNumber}</br></br><b>Confirm you want to <u>delete</u> this device:</b><br />";
             ConfirmDelete?.Show();
         }
 


### PR DESCRIPTION
@kenjohnson03 This is a one-liner text update I caught during today's demo to the CSAs.  
Going to go ahead and merge it so it can be included in the outstanding PR to main (and since it's just a text change).