### PR TITLE
Features/recent updates page

### DIFF
--- a/DelegationStation/Pages/RecentUpdates.razor
+++ b/DelegationStation/Pages/RecentUpdates.razor
@@ -1,0 +1,37 @@
+@page "/RecentUpdates"
+
+<PageTitle>Recent Updates</PageTitle>
+
+<h3>Recent Updates</h3>
+
+<div class="container">
+    <div class="card mb-3">
+        <div class="card-body">
+            <h5 class="card-title">v2.1 - Bulk Device Actions</h5>
+            <h6 class="card-subtitle mb-2 text-muted">2024</h6>
+            <p class="card-text">
+                Added the Bulk Devices page, allowing users to perform actions on multiple devices at once.
+            </p>
+        </div>
+    </div>
+
+    <div class="card mb-3">
+        <div class="card-body">
+            <h5 class="card-title">v2.0 - Tags &amp; Roles Management</h5>
+            <h6 class="card-subtitle mb-2 text-muted">2024</h6>
+            <p class="card-text">
+                Introduced device tag management and role-based access control with admin policies.
+            </p>
+        </div>
+    </div>
+
+    <div class="card mb-3">
+        <div class="card-body">
+            <h5 class="card-title">v1.0 - Initial Release</h5>
+            <h6 class="card-subtitle mb-2 text-muted">2023</h6>
+            <p class="card-text">
+                Initial release of DelegationStation with device management capabilities.
+            </p>
+        </div>
+    </div>
+</div>

--- a/DelegationStation/Pages/RecentUpdates.razor
+++ b/DelegationStation/Pages/RecentUpdates.razor
@@ -101,11 +101,14 @@
                 await LocalStorage.SetAsync(RecentUpdatesVersion.RecentUpdatesViewedVersionKey, RecentUpdatesVersion.CurrentVersion);
                 UpdatesNotification.MarkAsViewed();
             }
+            catch (InvalidOperationException ex) when (ex.Message.Contains("JavaScript interop calls cannot be issued", StringComparison.OrdinalIgnoreCase))
+            {
+                // Blazor Server prerendering (ServerPrerendered) doesn't allow JS interop; this will run again once interactive.
+            }
             catch (Exception e)
             {
                 const string errorMessage = "Error encountered while updating recent updates view status.";
                 logger.LogError(e, errorMessage);
-                // Error already logged via ILogger.
             }
         }
     }

--- a/DelegationStation/Pages/RecentUpdates.razor
+++ b/DelegationStation/Pages/RecentUpdates.razor
@@ -3,6 +3,7 @@
 @using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
 @inject ProtectedLocalStorage LocalStorage
 @inject RecentUpdatesNotificationService UpdatesNotification
+@inject ILogger<RoleEdit> logger
 
 <PageTitle>Recent Updates</PageTitle>
 
@@ -50,8 +51,11 @@
                 await LocalStorage.SetAsync("RecentUpdatesViewedVersion", RecentUpdatesVersion.CurrentVersion);
                 UpdatesNotification.MarkAsViewed();
             }
-            catch
+            catch (Exception e)
             {
+                var erMessage = $"Error encountered while updating recent updates view status.";
+                logger.LogError(e, $"{erMessage}");
+                Console.WriteLine(erMessage);
             }
         }
     }

--- a/DelegationStation/Pages/RecentUpdates.razor
+++ b/DelegationStation/Pages/RecentUpdates.razor
@@ -45,8 +45,14 @@
     {
         if (firstRender)
         {
-            await LocalStorage.SetAsync("RecentUpdatesViewedVersion", RecentUpdatesVersion.CurrentVersion);
-            UpdatesNotification.MarkAsViewed();
+            try
+            {
+                await LocalStorage.SetAsync("RecentUpdatesViewedVersion", RecentUpdatesVersion.CurrentVersion);
+                UpdatesNotification.MarkAsViewed();
+            }
+            catch
+            {
+            }
         }
     }
 }

--- a/DelegationStation/Pages/RecentUpdates.razor
+++ b/DelegationStation/Pages/RecentUpdates.razor
@@ -90,8 +90,7 @@
         {
             try
             {
-                const string recentUpdatesViewedVersionKey = "RecentUpdatesViewedVersion";
-                await LocalStorage.SetAsync(recentUpdatesViewedVersionKey, RecentUpdatesVersion.CurrentVersion);
+                await LocalStorage.SetAsync(RecentUpdatesVersion.RecentUpdatesViewedVersionKey, RecentUpdatesVersion.CurrentVersion);
                 UpdatesNotification.MarkAsViewed();
             }
             catch (Exception e)

--- a/DelegationStation/Pages/RecentUpdates.razor
+++ b/DelegationStation/Pages/RecentUpdates.razor
@@ -39,9 +39,51 @@
             </p>
         </div>
     </div>
+
+    <h3 class="mt-5">FAQ - Troubleshooting Tips</h3>
+
+    <div class="accordion">
+        @foreach (var (faq, index) in faqItems.Select((f, i) => (f, i)))
+        {
+            <div class="accordion-item">
+                <h2 class="accordion-header">
+                    <button class="accordion-button @(expandedIndex == index ? "" : "collapsed")" type="button" @onclick="() => ToggleFaq(index)" aria-expanded="@(expandedIndex == index)">
+                        <strong>@faq.Question</strong>
+                    </button>
+                </h2>
+                @if (expandedIndex == index)
+                {
+                    <div class="accordion-collapse collapse show">
+                        <div class="accordion-body">
+                            @faq.Answer
+                        </div>
+                    </div>
+                }
+            </div>
+        }
+    </div>
 </div>
 
 @code {
+    private int? expandedIndex;
+
+    private readonly List<(string Question, string Answer)> faqItems =
+    [
+        ("I can't see my Device Tag.",
+         "Make sure you are logged in with the correct account and PIM'd in successfully. If you are trying to view the PAW tag, you must be logged in with an ADM account. If that's not it, you may need to verify you are still in the correct group to view that tag."),
+        ("I tried to enter a device and the tool returns that it already exists, but I can't find the device when I search for it.",
+         "This usually indicates that someone has entered that device under a Device Tag that you don't have access to."),
+        ("My device isn't processing correctly on enrollment.",
+         "In order for Delegation Station to successfully process your device on enrollment, the Make/Model/Serial Number in the tool must match what Intune reads in from the BIOS settings of the device."),
+        ("My device is in the failed state. What should I do?",
+         "This indicates the device was unable to successfully sync to Corporate Identifiers after several retries and DS will no longer retry. One reason this can happen is that there is some issue with the Make, Model, Serial Number that prevents it from being added. The other is that DS attempted to sync it to Corporate Identifiers and we hit the tenant limit unexpectedly. In both cases, we recommend deleting it, checking the details and re-entering it again.")
+    ];
+
+    private void ToggleFaq(int index)
+    {
+        expandedIndex = expandedIndex == index ? null : index;
+    }
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)

--- a/DelegationStation/Pages/RecentUpdates.razor
+++ b/DelegationStation/Pages/RecentUpdates.razor
@@ -3,7 +3,7 @@
 @using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
 @inject ProtectedLocalStorage LocalStorage
 @inject RecentUpdatesNotificationService UpdatesNotification
-@inject ILogger<RoleEdit> logger
+@inject ILogger<RecentUpdates> logger
 
 <PageTitle>Recent Updates</PageTitle>
 
@@ -95,9 +95,9 @@
             }
             catch (Exception e)
             {
-                var erMessage = $"Error encountered while updating recent updates view status.";
-                logger.LogError(e, $"{erMessage}");
-                Console.WriteLine(erMessage);
+                const string errorMessage = "Error encountered while updating recent updates view status.";
+                logger.LogError(e, errorMessage);
+                Console.WriteLine(errorMessage);
             }
         }
     }

--- a/DelegationStation/Pages/RecentUpdates.razor
+++ b/DelegationStation/Pages/RecentUpdates.razor
@@ -1,10 +1,14 @@
 @page "/RecentUpdates"
+@using DelegationStation.Services
+@using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
+@inject ProtectedLocalStorage LocalStorage
+@inject RecentUpdatesNotificationService UpdatesNotification
 
 <PageTitle>Recent Updates</PageTitle>
 
 <h3>Recent Updates</h3>
 
-<div class="container">
+<div class="container-fluid px-0">
     <div class="card mb-3">
         <div class="card-body">
             <h5 class="card-title">v2.1 - Bulk Device Actions</h5>
@@ -35,3 +39,14 @@
         </div>
     </div>
 </div>
+
+@code {
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await LocalStorage.SetAsync("RecentUpdatesViewedVersion", RecentUpdatesVersion.CurrentVersion);
+            UpdatesNotification.MarkAsViewed();
+        }
+    }
+}

--- a/DelegationStation/Pages/RecentUpdates.razor
+++ b/DelegationStation/Pages/RecentUpdates.razor
@@ -90,14 +90,14 @@
         {
             try
             {
-                await LocalStorage.SetAsync("RecentUpdatesViewedVersion", RecentUpdatesVersion.CurrentVersion);
+                const string recentUpdatesViewedVersionKey = "RecentUpdatesViewedVersion";
+                await LocalStorage.SetAsync(recentUpdatesViewedVersionKey, RecentUpdatesVersion.CurrentVersion);
                 UpdatesNotification.MarkAsViewed();
-            }
             catch (Exception e)
             {
                 const string errorMessage = "Error encountered while updating recent updates view status.";
                 logger.LogError(e, errorMessage);
-                Console.WriteLine(errorMessage);
+                // Error already logged via ILogger.
             }
         }
     }

--- a/DelegationStation/Pages/RecentUpdates.razor
+++ b/DelegationStation/Pages/RecentUpdates.razor
@@ -47,13 +47,21 @@
         {
             <div class="accordion-item">
                 <h2 class="accordion-header">
-                    <button class="accordion-button @(expandedIndex == index ? "" : "collapsed")" type="button" @onclick="() => ToggleFaq(index)" aria-expanded="@(expandedIndex == index)">
+                    <button class="accordion-button @(expandedIndex == index ? "" : "collapsed")"
+                            type="button"
+                            @onclick="() => ToggleFaq(index)"
+                            aria-expanded="@(expandedIndex == index)"
+                            aria-controls="@($"faq-body-{index}")"
+                            id="@($"faq-header-{index}")">
                         <strong>@faq.Question</strong>
                     </button>
                 </h2>
                 @if (expandedIndex == index)
                 {
-                    <div class="accordion-collapse collapse show">
+                    <div class="accordion-collapse collapse show"
+                         id="@($"faq-body-{index}")"
+                         role="region"
+                         aria-labelledby="@($"faq-header-{index}")">
                         <div class="accordion-body">
                             @faq.Answer
                         </div>

--- a/DelegationStation/Pages/RecentUpdates.razor
+++ b/DelegationStation/Pages/RecentUpdates.razor
@@ -93,6 +93,7 @@
                 const string recentUpdatesViewedVersionKey = "RecentUpdatesViewedVersion";
                 await LocalStorage.SetAsync(recentUpdatesViewedVersionKey, RecentUpdatesVersion.CurrentVersion);
                 UpdatesNotification.MarkAsViewed();
+            }
             catch (Exception e)
             {
                 const string errorMessage = "Error encountered while updating recent updates view status.";

--- a/DelegationStation/Program.cs
+++ b/DelegationStation/Program.cs
@@ -77,6 +77,7 @@ builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor()
     .AddMicrosoftIdentityConsentHandler();
 
+builder.Services.AddScoped<RecentUpdatesNotificationService>();
 builder.Services.AddSingleton<IAuthorizationHandler, DeviceTagAuthorizationHandler>();
 builder.Services.AddSingleton<IDeviceTagDBService, DeviceTagDBService>();
 builder.Services.AddSingleton<IDeviceDBService, DeviceDBService>();

--- a/DelegationStation/Services/RecentUpdatesNotificationService.cs
+++ b/DelegationStation/Services/RecentUpdatesNotificationService.cs
@@ -1,0 +1,12 @@
+namespace DelegationStation.Services
+{
+    public class RecentUpdatesNotificationService
+    {
+        public event Action? OnUpdatesViewed;
+
+        public void MarkAsViewed()
+        {
+            OnUpdatesViewed?.Invoke();
+        }
+    }
+}

--- a/DelegationStation/Services/RecentUpdatesVersion.cs
+++ b/DelegationStation/Services/RecentUpdatesVersion.cs
@@ -1,0 +1,10 @@
+namespace DelegationStation.Services
+{
+    public static class RecentUpdatesVersion
+    {
+        /// <summary>
+        /// Increment this value whenever new updates are added to the RecentUpdates page.
+        /// </summary>
+        public const string CurrentVersion = "2.1";
+    }
+}

--- a/DelegationStation/Services/RecentUpdatesVersion.cs
+++ b/DelegationStation/Services/RecentUpdatesVersion.cs
@@ -6,5 +6,6 @@ namespace DelegationStation.Services
         /// Increment this value whenever new updates are added to the RecentUpdates page.
         /// </summary>
         public const string CurrentVersion = "2.1";
+        public const string RecentUpdatesViewedVersionKey = "RecentUpdatesViewedVersion";
     }
 }

--- a/DelegationStation/Shared/NavMenu.razor
+++ b/DelegationStation/Shared/NavMenu.razor
@@ -24,20 +24,25 @@
                 <span class="oi oi-tags" aria-hidden="true"></span> Tags
             </NavLink>
         </div>
+        <AuthorizeView Policy="DelegationStationAdmin">
+            <Authorized>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="Roles" Match="NavLinkMatch.Prefix">
+                        <span class="oi oi-shield" aria-hidden="true"></span> Roles
+                    </NavLink>
+                </div>
+            </Authorized>
+        </AuthorizeView>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="RecentUpdates" Match="NavLinkMatch.Prefix">
-                <span class="oi oi-info" aria-hidden="true"></span> Recent Updates
+                <span class="oi oi-info" aria-hidden="true" style="position: relative; display: inline-block;">
+                    @if (showUpdatesBadge)
+                    {
+                        <span class="bg-danger rounded-circle" style="position: absolute; top: 25%; left: 50%; transform: translate(-50%, -50%); width: 8px; height: 8px;"></span>
+                    }
+                </span> Recent Updates
             </NavLink>
-        </div>
-<AuthorizeView Policy="DelegationStationAdmin">
-    <Authorized>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="Roles" Match="NavLinkMatch.Prefix">
-                <span class="oi oi-shield" aria-hidden="true"></span> Roles
-            </NavLink>
-        </div>
-        </Authorized>
-        </AuthorizeView>
+        </div> 
     </nav>
 </div>
 

--- a/DelegationStation/Shared/NavMenu.razor
+++ b/DelegationStation/Shared/NavMenu.razor
@@ -24,6 +24,11 @@
                 <span class="oi oi-tags" aria-hidden="true"></span> Tags
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="RecentUpdates" Match="NavLinkMatch.Prefix">
+                <span class="oi oi-info" aria-hidden="true"></span> Recent Updates
+            </NavLink>
+        </div>
 <AuthorizeView Policy="DelegationStationAdmin">
     <Authorized>
         <div class="nav-item px-3">

--- a/DelegationStation/Shared/NavMenu.razor
+++ b/DelegationStation/Shared/NavMenu.razor
@@ -35,10 +35,12 @@
         </AuthorizeView>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="RecentUpdates" Match="NavLinkMatch.Prefix">
-                <span class="oi oi-info" aria-hidden="true" style="position: relative; display: inline-block;">
+                <span style="position: relative; display: inline-block;">
+                    <span class="oi oi-info" aria-hidden="true"></span>
                     @if (showUpdatesBadge)
                     {
-                        <span class="bg-danger rounded-circle" style="position: absolute; top: 25%; left: 50%; transform: translate(-50%, -50%); width: 8px; height: 8px;"></span>
+                        <span class="bg-danger rounded-circle" aria-hidden="true" style="position: absolute; top: 25%; left: 50%; transform: translate(-50%, -50%); width: 8px; height: 8px;"></span>
+                        <span class="visually-hidden">New updates available</span>
                     }
                 </span> Recent Updates
             </NavLink>

--- a/DelegationStation/Shared/NavMenu.razor.cs
+++ b/DelegationStation/Shared/NavMenu.razor.cs
@@ -15,6 +15,9 @@ namespace DelegationStation.Shared
         [Inject]
         private RecentUpdatesNotificationService UpdatesNotification { get; set; } = default!;
 
+        [Inject]
+        private ILogger<NavMenu> Logger { get; set; } = default!;
+
         private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
 
         protected override void OnInitialized()
@@ -31,8 +34,9 @@ namespace DelegationStation.Shared
                     var result = await LocalStorage.GetAsync<string>(RecentUpdatesVersion.RecentUpdatesViewedVersionKey);
                     showUpdatesBadge = !result.Success || result.Value != RecentUpdatesVersion.CurrentVersion;
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    Logger.LogWarning(ex, "Failed to read recent updates view status from protected local storage.");
                     showUpdatesBadge = true;
                 }
                 StateHasChanged();

--- a/DelegationStation/Shared/NavMenu.razor.cs
+++ b/DelegationStation/Shared/NavMenu.razor.cs
@@ -33,13 +33,18 @@ namespace DelegationStation.Shared
                 {
                     var result = await LocalStorage.GetAsync<string>(RecentUpdatesVersion.RecentUpdatesViewedVersionKey);
                     showUpdatesBadge = !result.Success || result.Value != RecentUpdatesVersion.CurrentVersion;
+                    StateHasChanged();
+                }
+                catch (InvalidOperationException ex) when (ex.Message.Contains("JavaScript interop calls cannot be issued", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Blazor Server prerendering (ServerPrerendered) doesn't allow JS interop; this will run again once interactive.
                 }
                 catch (Exception ex)
                 {
                     Logger.LogWarning(ex, "Failed to read recent updates view status from protected local storage.");
                     showUpdatesBadge = true;
+                    StateHasChanged();
                 }
-                StateHasChanged();
             }
         }
 

--- a/DelegationStation/Shared/NavMenu.razor.cs
+++ b/DelegationStation/Shared/NavMenu.razor.cs
@@ -31,6 +31,7 @@ namespace DelegationStation.Shared
                     const string recentUpdatesViewedVersionKey = "RecentUpdatesViewedVersion";
                     var result = await LocalStorage.GetAsync<string>(recentUpdatesViewedVersionKey);
                     showUpdatesBadge = !result.Success || result.Value != RecentUpdatesVersion.CurrentVersion;
+                }
                 catch (Exception)
                 {
                     showUpdatesBadge = true;

--- a/DelegationStation/Shared/NavMenu.razor.cs
+++ b/DelegationStation/Shared/NavMenu.razor.cs
@@ -1,14 +1,58 @@
+using DelegationStation.Services;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+
 namespace DelegationStation.Shared
 {
-    public partial class NavMenu
+    public partial class NavMenu : IDisposable
     {
         private bool collapseNavMenu = true;
+        private bool showUpdatesBadge = false;
+
+        [Inject]
+        private ProtectedLocalStorage LocalStorage { get; set; } = default!;
+
+        [Inject]
+        private RecentUpdatesNotificationService UpdatesNotification { get; set; } = default!;
 
         private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
+
+        protected override void OnInitialized()
+        {
+            UpdatesNotification.OnUpdatesViewed += HandleUpdatesViewed;
+        }
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (firstRender)
+            {
+                try
+                {
+                    var result = await LocalStorage.GetAsync<string>("RecentUpdatesViewedVersion");
+                    showUpdatesBadge = !result.Success || result.Value != RecentUpdatesVersion.CurrentVersion;
+                }
+                catch
+                {
+                    showUpdatesBadge = true;
+                }
+                StateHasChanged();
+            }
+        }
+
+        private void HandleUpdatesViewed()
+        {
+            showUpdatesBadge = false;
+            InvokeAsync(StateHasChanged);
+        }
 
         private void ToggleNavMenu()
         {
             collapseNavMenu = !collapseNavMenu;
+        }
+
+        public void Dispose()
+        {
+            UpdatesNotification.OnUpdatesViewed -= HandleUpdatesViewed;
         }
     }
 }

--- a/DelegationStation/Shared/NavMenu.razor.cs
+++ b/DelegationStation/Shared/NavMenu.razor.cs
@@ -28,8 +28,7 @@ namespace DelegationStation.Shared
             {
                 try
                 {
-                    const string recentUpdatesViewedVersionKey = "RecentUpdatesViewedVersion";
-                    var result = await LocalStorage.GetAsync<string>(recentUpdatesViewedVersionKey);
+                    var result = await LocalStorage.GetAsync<string>(RecentUpdatesVersion.RecentUpdatesViewedVersionKey);
                     showUpdatesBadge = !result.Success || result.Value != RecentUpdatesVersion.CurrentVersion;
                 }
                 catch (Exception)

--- a/DelegationStation/Shared/NavMenu.razor.cs
+++ b/DelegationStation/Shared/NavMenu.razor.cs
@@ -28,9 +28,9 @@ namespace DelegationStation.Shared
             {
                 try
                 {
-                    var result = await LocalStorage.GetAsync<string>("RecentUpdatesViewedVersion");
+                    const string recentUpdatesViewedVersionKey = "RecentUpdatesViewedVersion";
+                    var result = await LocalStorage.GetAsync<string>(recentUpdatesViewedVersionKey);
                     showUpdatesBadge = !result.Success || result.Value != RecentUpdatesVersion.CurrentVersion;
-                }
                 catch (Exception)
                 {
                     showUpdatesBadge = true;

--- a/DelegationStation/Shared/NavMenu.razor.cs
+++ b/DelegationStation/Shared/NavMenu.razor.cs
@@ -31,7 +31,7 @@ namespace DelegationStation.Shared
                     var result = await LocalStorage.GetAsync<string>("RecentUpdatesViewedVersion");
                     showUpdatesBadge = !result.Success || result.Value != RecentUpdatesVersion.CurrentVersion;
                 }
-                catch
+                catch (Exception)
                 {
                     showUpdatesBadge = true;
                 }

--- a/DelegationStationTests/Pages/NavMenuTests.cs
+++ b/DelegationStationTests/Pages/NavMenuTests.cs
@@ -1,5 +1,7 @@
-﻿using DelegationStation.Pages;
+﻿using Bunit;
+using DelegationStation.Pages;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.DataProtection;
 using DelegationStation.Interfaces;
 using Microsoft.QualityTools.Testing.Fakes;
 using Microsoft.Extensions.Configuration;
@@ -42,13 +44,17 @@ namespace DelegationStationTests.Pages
                 // Add Dependent Services
                 Services.AddSingleton<Microsoft.Extensions.Configuration.IConfiguration>(configuration);
                 Services.AddSingleton<IHttpContextAccessor>(httpContext);
+                Services.AddSingleton<DelegationStation.Services.RecentUpdatesNotificationService>();
+                Services.AddDataProtection();
+                Services.AddSingleton<Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage.ProtectedLocalStorage>();
+                JSInterop.Mode = JSRuntimeMode.Loose;
 
 
                 // Act
                 var cut = RenderComponent<NavMenu>();
 
                 // Assert
-                Assert.IsTrue(cut.Markup.Contains("<a href=\"Roles\" class=\"nav-link\"><span class=\"oi oi-shield\" aria-hidden=\"true\" b-l9c7g71qbx></span> Roles\r\n            </a></div></nav></div>"), $"Role link should be rendered. \\nActual:\\n{cut.Markup}\"");
+                Assert.IsTrue(cut.Markup.Contains("Roles"), $"Role link should be rendered. Actual: {cut.Markup}");
 
 
             }
@@ -85,13 +91,17 @@ namespace DelegationStationTests.Pages
                 // Add Dependent Services
                 Services.AddSingleton<Microsoft.Extensions.Configuration.IConfiguration>(configuration);
                 Services.AddSingleton<IHttpContextAccessor>(httpContext);
+                Services.AddSingleton<DelegationStation.Services.RecentUpdatesNotificationService>();
+                Services.AddDataProtection();
+                Services.AddSingleton<Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage.ProtectedLocalStorage>();
+                JSInterop.Mode = JSRuntimeMode.Loose;
 
 
                 // Act
                 var cut = RenderComponent<NavMenu>();
 
                 // Assert
-                Assert.IsFalse(cut.Markup.Contains("Roles"), $"Menu should not display Roles link. \\nActual:\\n{cut.Markup}\"");
+                Assert.IsFalse(cut.Markup.Contains("Roles"), $"Menu should not display Roles link. Actual: {cut.Markup}");
             }
         }
     }

--- a/DelegationStationTests/Pages/NavMenuTests.cs
+++ b/DelegationStationTests/Pages/NavMenuTests.cs
@@ -1,5 +1,6 @@
 ﻿using Bunit;
 using DelegationStation.Pages;
+using DelegationStation.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.DataProtection;
 using DelegationStation.Interfaces;
@@ -102,6 +103,89 @@ Assert.AreEqual(1, cut.FindAll("a[href='Roles']").Count, $"Role link should be r
 
                 // Assert
 Assert.AreEqual(0, cut.FindAll("a[href='Roles']").Count, $"Menu should not display Roles link. Actual: {cut.Markup}");
+            }
+        }
+
+        [TestMethod]
+        public void DisplayUpdatesBadgeWhenUpdatesNotViewed()
+        {
+            using (ShimsContext.Create())
+            {
+                // Arrange
+                Guid defaultId = Guid.NewGuid();
+                var authContext = this.AddTestAuthorization();
+                authContext.SetAuthorized("TEST USER");
+                authContext.SetClaims(new System.Security.Claims.Claim("name", "TEST USER"));
+
+                var myConfiguration = new Dictionary<string, string?>
+                {
+                    {"DefaultAdminGroupObjectId", defaultId.ToString()}
+                };
+
+                var configuration = new ConfigurationBuilder()
+                    .AddInMemoryCollection(myConfiguration)
+                    .Build();
+
+                var httpContext = new HttpContextAccessor();
+                httpContext.HttpContext = new DefaultHttpContext();
+
+                Services.AddSingleton<IConfiguration>(configuration);
+                Services.AddSingleton<IHttpContextAccessor>(httpContext);
+                Services.AddSingleton<RecentUpdatesNotificationService>();
+                Services.AddDataProtection();
+                Services.AddSingleton<Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage.ProtectedLocalStorage>();
+                JSInterop.Mode = JSRuntimeMode.Loose;
+
+                // Act
+                var cut = RenderComponent<NavMenu>();
+
+                // Assert - badge should show because local storage has no viewed version
+                Assert.AreEqual(1, cut.FindAll(".bg-danger.rounded-circle").Count, $"Updates badge should be displayed when updates have not been viewed. Actual: {cut.Markup}");
+                Assert.AreEqual(1, cut.FindAll(".visually-hidden").Count, $"Accessible label for new updates should be present. Actual: {cut.Markup}");
+            }
+        }
+
+        [TestMethod]
+        public void HideUpdatesBadgeAfterUpdatesViewed()
+        {
+            using (ShimsContext.Create())
+            {
+                // Arrange
+                Guid defaultId = Guid.NewGuid();
+                var authContext = this.AddTestAuthorization();
+                authContext.SetAuthorized("TEST USER");
+                authContext.SetClaims(new System.Security.Claims.Claim("name", "TEST USER"));
+
+                var myConfiguration = new Dictionary<string, string?>
+                {
+                    {"DefaultAdminGroupObjectId", defaultId.ToString()}
+                };
+
+                var configuration = new ConfigurationBuilder()
+                    .AddInMemoryCollection(myConfiguration)
+                    .Build();
+
+                var httpContext = new HttpContextAccessor();
+                httpContext.HttpContext = new DefaultHttpContext();
+
+                var updatesNotification = new RecentUpdatesNotificationService();
+
+                Services.AddSingleton<IConfiguration>(configuration);
+                Services.AddSingleton<IHttpContextAccessor>(httpContext);
+                Services.AddSingleton(updatesNotification);
+                Services.AddDataProtection();
+                Services.AddSingleton<Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage.ProtectedLocalStorage>();
+                JSInterop.Mode = JSRuntimeMode.Loose;
+
+                var cut = RenderComponent<NavMenu>();
+
+                // Act - simulate the user viewing the RecentUpdates page
+                updatesNotification.MarkAsViewed();
+                cut.WaitForState(() => cut.FindAll(".bg-danger.rounded-circle").Count == 0);
+
+                // Assert - badge should be hidden after updates are marked as viewed
+                Assert.AreEqual(0, cut.FindAll(".bg-danger.rounded-circle").Count, $"Updates badge should not be displayed after updates have been viewed. Actual: {cut.Markup}");
+                Assert.AreEqual(0, cut.FindAll(".visually-hidden").Count, $"Accessible label for new updates should not be present after viewed. Actual: {cut.Markup}");
             }
         }
     }

--- a/DelegationStationTests/Pages/NavMenuTests.cs
+++ b/DelegationStationTests/Pages/NavMenuTests.cs
@@ -54,7 +54,7 @@ namespace DelegationStationTests.Pages
                 var cut = RenderComponent<NavMenu>();
 
                 // Assert
-                Assert.IsTrue(cut.Markup.Contains("Roles"), $"Role link should be rendered. Actual: {cut.Markup}");
+Assert.AreEqual(1, cut.FindAll("a[href='Roles']").Count, $"Role link should be rendered. Actual: {cut.Markup}");
 
 
             }
@@ -101,7 +101,7 @@ namespace DelegationStationTests.Pages
                 var cut = RenderComponent<NavMenu>();
 
                 // Assert
-                Assert.IsFalse(cut.Markup.Contains("Roles"), $"Menu should not display Roles link. Actual: {cut.Markup}");
+Assert.AreEqual(0, cut.FindAll("a[href='Roles']").Count, $"Menu should not display Roles link. Actual: {cut.Markup}");
             }
         }
     }


### PR DESCRIPTION
Adds a recent updates page with notification system.
The red dot shows based off encrypted local storage, meaning that if the same user uses DelegationStation from a different computer, they may need to clear the notification again as it references user & device to determine if they need to be notified. 
Once this has been merged, we need to make sure we update the UpdatesPage and Version number to have accurate information before we merge to main and on all subsequent releases to main.
There are ways to automate this in the long run that may be worth looking into.
<img width="247" height="291" alt="image" src="https://github.com/user-attachments/assets/e7270789-3183-48a9-bde2-d0dc5c80a892" />
<img width="1121" height="832" alt="image" src="https://github.com/user-attachments/assets/c21075b3-ad09-4ca3-a426-cbd9441862cb" />
