### PR TITLE
Update regex to allow only spaces in Device validation

### DIFF
--- a/DelegationSharedLibrary/Models/Device.cs
+++ b/DelegationSharedLibrary/Models/Device.cs
@@ -11,15 +11,15 @@ namespace DelegationStationShared.Models
         public Guid Id { get; set; }
 
         [Required(AllowEmptyStrings = false, ErrorMessage = "Make is Required")]
-        [RegularExpression(@"^[a-zA-Z0-9\-_.,&\(\)\s]+$", ErrorMessage = "Only use letters, numbers, or the following special characters: -_&().,")]
+        [RegularExpression(@"^[a-zA-Z0-9\-_.,&\(\) ]+$", ErrorMessage = "Only use letters, numbers, or the following special characters: -_&().,")]
         public string Make { get; set; }
 
         [Required(AllowEmptyStrings = false, ErrorMessage = "Model is Required")]
-        [RegularExpression(@"^[a-zA-Z0-9\-_.,&\(\)+\s]+$", ErrorMessage = "Only use letters, numbers, or the following special characters: -_&().+,")]
+        [RegularExpression(@"^[a-zA-Z0-9\-_.,&\(\)+ ]+$", ErrorMessage = "Only use letters, numbers, or the following special characters: -_&().+,")]
         public string Model { get; set; }
 
         [Required(AllowEmptyStrings = false, ErrorMessage = "Serial Number is Required")]
-        [RegularExpression(@"^[a-zA-Z0-9\-_.\s]+$", ErrorMessage = "Only use letters, numbers, -, _, or . for SerialNumber value.")]
+        [RegularExpression(@"^[a-zA-Z0-9\-_. ]+$", ErrorMessage = "Only use letters, numbers, -, _, or . for SerialNumber value.")]
         public string SerialNumber { get; set; }
 
         // Validation applicable to all devices done here


### PR DESCRIPTION
Replaced \s with literal space in Make, Model, and SerialNumber regex patterns to restrict allowed whitespace to spaces only, improving input validation.