### PR TITLE
Move CorpIDCounter to DelegationSharedLibrary to fix SeedCorpIDCounter WebJob

### DIFF
--- a/CorporateIdentifierSync.Tests/AddNewDevicesTests.cs
+++ b/CorporateIdentifierSync.Tests/AddNewDevicesTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Net;
 using CorporateIdentifierSync.Enums;
 using CorporateIdentifierSync.Interfaces;
-using CorporateIdentifierSync.Models;
+using DelegationStationShared.Models;
 using DelegationStationShared.Enums;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Functions.Worker;

--- a/CorporateIdentifierSync.Tests/AddNotSyncingDevicesInEnabledTagsTests.cs
+++ b/CorporateIdentifierSync.Tests/AddNotSyncingDevicesInEnabledTagsTests.cs
@@ -1,6 +1,6 @@
 using CorporateIdentifierSync.Enums;
 using CorporateIdentifierSync.Interfaces;
-using CorporateIdentifierSync.Models;
+using DelegationStationShared.Models;
 using DelegationStationShared.Enums;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Functions.Worker;

--- a/CorporateIdentifierSync.Tests/ConfirmSyncTests.cs
+++ b/CorporateIdentifierSync.Tests/ConfirmSyncTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Net;
 using CorporateIdentifierSync.Enums;
 using CorporateIdentifierSync.Interfaces;
-using CorporateIdentifierSync.Models;
 using DelegationStationShared.Enums;
 using DelegationStationShared.Models;
 using Microsoft.Azure.Cosmos;

--- a/CorporateIdentifierSync.Tests/CorpIDCounterTests.cs
+++ b/CorporateIdentifierSync.Tests/CorpIDCounterTests.cs
@@ -1,4 +1,4 @@
-using CorporateIdentifierSync.Models;
+using DelegationStationShared.Models;
 
 namespace CorporateIdentifierSync.Tests.CorpIDCounterTests
 {

--- a/CorporateIdentifierSync.Tests/CorpIdCapacityManagerTests.cs
+++ b/CorporateIdentifierSync.Tests/CorpIdCapacityManagerTests.cs
@@ -1,6 +1,6 @@
 using CorporateIdentifierSync;
 using CorporateIdentifierSync.Interfaces;
-using CorporateIdentifierSync.Models;
+using DelegationStationShared.Models;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 using Device = DelegationStationShared.Models.Device;

--- a/CorporateIdentifierSync.Tests/DeviceDeletionTests.cs
+++ b/CorporateIdentifierSync.Tests/DeviceDeletionTests.cs
@@ -1,6 +1,6 @@
 ﻿using CorporateIdentifierSync.Enums;
 using CorporateIdentifierSync.Interfaces;
-using CorporateIdentifierSync.Models;
+using DelegationStationShared.Models;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;

--- a/CorporateIdentifierSync.Tests/ReconcileSyncStateTests.cs
+++ b/CorporateIdentifierSync.Tests/ReconcileSyncStateTests.cs
@@ -1,6 +1,6 @@
 ﻿using CorporateIdentifierSync.Enums;
 using CorporateIdentifierSync.Interfaces;
-using CorporateIdentifierSync.Models;
+using DelegationStationShared.Models;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using Microsoft.Graph.Beta.Models;

--- a/CorporateIdentifierSync.Tests/RemovedSyncedDevicesInDisabledTagsTests.cs
+++ b/CorporateIdentifierSync.Tests/RemovedSyncedDevicesInDisabledTagsTests.cs
@@ -1,6 +1,6 @@
 using CorporateIdentifierSync.Enums;
 using CorporateIdentifierSync.Interfaces;
-using CorporateIdentifierSync.Models;
+using DelegationStationShared.Models;
 using DelegationStationShared.Enums;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Functions.Worker;

--- a/CorporateIdentifierSync/CorpIDAudit.cs
+++ b/CorporateIdentifierSync/CorpIDAudit.cs
@@ -1,6 +1,6 @@
 using CorporateIdentifierSync.Interfaces;
-using CorporateIdentifierSync.Models;
 using DelegationStationShared;
+using DelegationStationShared.Models;
 using DelegationStationShared.Extensions;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;

--- a/CorporateIdentifierSync/Interfaces/ICosmosDbService.cs
+++ b/CorporateIdentifierSync/Interfaces/ICosmosDbService.cs
@@ -1,5 +1,4 @@
-﻿using CorporateIdentifierSync.Models;
-using DelegationStationShared.Models;
+﻿using DelegationStationShared.Models;
 
 namespace CorporateIdentifierSync.Interfaces
 {

--- a/CorporateIdentifierSync/Services/CosmosDbService.cs
+++ b/CorporateIdentifierSync/Services/CosmosDbService.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Azure.Cosmos;
 using CorporateIdentifierSync.Interfaces;
-using CorporateIdentifierSync.Models;
 using DelegationStationShared.Extensions;
 using Device = DelegationStationShared.Models.Device;
 using DelegationStationShared;

--- a/DelegationSharedLibrary/Models/CorpIDCounter.cs
+++ b/DelegationSharedLibrary/Models/CorpIDCounter.cs
@@ -1,7 +1,7 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System.ComponentModel.DataAnnotations;
 
-namespace CorporateIdentifierSync.Models
+namespace DelegationStationShared.Models
 {
     public class CorpIDCounter
     {

--- a/SeedCorpIDCounter/SeedCorpIDCounter.csproj
+++ b/SeedCorpIDCounter/SeedCorpIDCounter.csproj
@@ -15,7 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-	<ProjectReference Include="..\CorporateIdentifierSync\CorporateIdentifierSync.csproj" />
 	<ProjectReference Include="..\DelegationSharedLibrary\DelegationSharedLibrary.csproj" />
   </ItemGroup>
 

--- a/SeedCorpIDCounter/SeedCorpIDCounterJob.cs
+++ b/SeedCorpIDCounter/SeedCorpIDCounterJob.cs
@@ -4,7 +4,7 @@ using DelegationStationShared;
 using DelegationStationShared.Extensions;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Logging;
-using CorporateIdentifierSync.Models;
+using DelegationStationShared.Models;
 
 namespace SeedCorpIDCounter
 {


### PR DESCRIPTION
## Why

The `SeedCorpIDCounter` WebJob was failing in Azure because `CorporateIdentifierSync.exe` was being included in its publish artifact. `SeedCorpIDCounter` only needed the `CorpIDCounter` model from `CorporateIdentifierSync`, but because that project is an Azure Functions `Exe`, the full executable was pulled in as a transitive output -- causing the WebJob runtime to try to launch it.

## What changed

`CorpIDCounter` has been moved from `CorporateIdentifierSync/Models/` into `DelegationSharedLibrary/Models/`, under the `DelegationStationShared.Models` namespace. Both projects already reference `DelegationSharedLibrary`, so no new dependencies were introduced.

- `DelegationSharedLibrary/Models/CorpIDCounter.cs` -- new home for the model (namespace updated)
- `CorporateIdentifierSync/Models/CorpIDCounter.cs` -- deleted
- `CorporateIdentifierSync/CorpIDAudit.cs`, `Interfaces/ICosmosDbService.cs`, `Services/CosmosDbService.cs` -- `using CorporateIdentifierSync.Models` replaced with `using DelegationStationShared.Models`
- `SeedCorpIDCounter/SeedCorpIDCounterJob.cs` -- same `using` update
- `SeedCorpIDCounter/SeedCorpIDCounter.csproj` -- `CorporateIdentifierSync` project reference removed; only `DelegationSharedLibrary` remains

Both projects build cleanly with 0 warnings and 0 errors after the change.