### PR TITLE
Prevent duplicate serial numbers for non-Windows devices

### DIFF
--- a/DelegationStation.Tests/Pages/DevicesAddDeviceTests.cs
+++ b/DelegationStation.Tests/Pages/DevicesAddDeviceTests.cs
@@ -73,6 +73,9 @@ namespace DelegationStation.Tests.Pages
         /// Fills in the add-device form fields and clicks the Add button.
         /// osValue must be the enum NAME as rendered by @os in the razor (e.g. "Windows", "MacOS", "iOS", "Android").
         /// The option tag renders value=@os which outputs the enum name, not the integer.
+        ///
+        /// InputText components in .NET 8 bind via oninput, so .Input() must be used (not .Change())
+        /// for those fields. InputSelect and native checkboxes use onchange, so .Change() is correct.
         /// </summary>
         private static void FillAndSubmitAddForm(
             IRenderedComponent<Devices> cut,
@@ -81,11 +84,13 @@ namespace DelegationStation.Tests.Pages
             string serialNumber,
             string osValue)
         {
-            cut.Find("#DeviceMake").Change(make);
-            cut.Find("#DeviceModel").Change(model);
-            cut.Find("#SerialNumber").Change(serialNumber);
+            // InputText uses @bind-value:event="oninput" in .NET 8 — use .Input() to fire the oninput event
+            cut.Find("#DeviceMake").Input(make);
+            cut.Find("#DeviceModel").Input(model);
+            cut.Find("#SerialNumber").Input(serialNumber);
+            // InputSelect uses onchange — .Change() is correct here
             cut.Find("#OS").Change(osValue);
-            // Select the first available tag via its checkbox
+            // Native checkbox with @onchange — .Change() is correct here
             cut.Find(".form-check-input").Change(true);
             cut.Find("input[value='Add']").Click();
         }

--- a/DelegationStation.Tests/Pages/DevicesAddDeviceTests.cs
+++ b/DelegationStation.Tests/Pages/DevicesAddDeviceTests.cs
@@ -52,7 +52,7 @@ namespace DelegationStation.Tests.Pages
             {
                 GetDevicesAsyncIEnumerableOfStringInt32Int32 =
                     (groupIds, pageSize, currentPage) => Task.FromResult(new List<Device>()),
-                AddOrUpdateDeviceAsyncDevice = addOrUpdateStub
+                AddOrUpdateDeviceAsyncDevice = device => addOrUpdateStub(device)
             };
 
             var config = new ConfigurationBuilder()

--- a/DelegationStation.Tests/Pages/DevicesAddDeviceTests.cs
+++ b/DelegationStation.Tests/Pages/DevicesAddDeviceTests.cs
@@ -71,7 +71,8 @@ namespace DelegationStation.Tests.Pages
 
         /// <summary>
         /// Fills in the add-device form fields and clicks the Add button.
-        /// osValue is the integer string of the DeviceOS enum (e.g. "1"=Windows, "2"=MacOS, "3"=iOS, "4"=Android).
+        /// osValue must be the enum NAME as rendered by @os in the razor (e.g. "Windows", "MacOS", "iOS", "Android").
+        /// The option tag renders value=@os which outputs the enum name, not the integer.
         /// </summary>
         private static void FillAndSubmitAddForm(
             IRenderedComponent<Devices> cut,
@@ -90,10 +91,10 @@ namespace DelegationStation.Tests.Pages
         }
 
         [TestMethod]
-        [DataRow("2", "MacOS")]
-        [DataRow("3", "iOS")]
-        [DataRow("4", "Android")]
-        public void AddDevice_NonWindowsDevice_DuplicateSerial_ShowsErrorMessage(string osValue, string osDisplayName)
+        [DataRow("MacOS")]
+        [DataRow("iOS")]
+        [DataRow("Android")]
+        public void AddDevice_NonWindowsDevice_DuplicateSerial_ShowsErrorMessage(string osValue)
         {
             using (ShimsContext.Create())
             {
@@ -111,17 +112,17 @@ namespace DelegationStation.Tests.Pages
                 cut.WaitForAssertion(() =>
                     Assert.IsTrue(
                         cut.Markup.Contains(DuplicateSerialErrorMessage),
-                        $"Expected duplicate serial error for {osDisplayName} device. Markup: {cut.Markup}"
+                        $"Expected duplicate serial error for {osValue} device. Markup: {cut.Markup}"
                     )
                 );
             }
         }
 
         [TestMethod]
-        [DataRow("2", "MacOS")]
-        [DataRow("3", "iOS")]
-        [DataRow("4", "Android")]
-        public void AddDevice_NonWindowsDevice_UniqueSerial_ShowsSuccessMessage(string osValue, string osDisplayName)
+        [DataRow("MacOS")]
+        [DataRow("iOS")]
+        [DataRow("Android")]
+        public void AddDevice_NonWindowsDevice_UniqueSerial_ShowsSuccessMessage(string osValue)
         {
             using (ShimsContext.Create())
             {
@@ -140,7 +141,7 @@ namespace DelegationStation.Tests.Pages
                 cut.WaitForAssertion(() =>
                     Assert.IsTrue(
                         cut.Markup.Contains("Device added successfully"),
-                        $"Expected success message for {osDisplayName} device with unique serial. Markup: {cut.Markup}"
+                        $"Expected success message for {osValue} device with unique serial. Markup: {cut.Markup}"
                     )
                 );
             }
@@ -160,8 +161,8 @@ namespace DelegationStation.Tests.Pages
                     device => Task.FromResult(addedDevice)
                 );
 
-                // Act - "1" = DeviceOS.Windows
-                FillAndSubmitAddForm(cut, "Dell", "Latitude", "SN12345", "1");
+                // Act - "Windows" matches the enum name rendered in option value=@os
+                FillAndSubmitAddForm(cut, "Dell", "Latitude", "SN12345", "Windows");
 
                 // Assert
                 cut.WaitForAssertion(() =>
@@ -185,8 +186,8 @@ namespace DelegationStation.Tests.Pages
                     device => Task.FromException<Device>(new Exception(DuplicateSerialErrorMessage))
                 );
 
-                // Act - MacOS device
-                FillAndSubmitAddForm(cut, "Apple", "MacBook", "SN12345", "2");
+                // Act - MacOS device; "MacOS" matches the enum name rendered in option value=@os
+                FillAndSubmitAddForm(cut, "Apple", "MacBook", "SN12345", "MacOS");
 
                 // Assert: error message is shown in an error-styled alert and includes the correlation ID context
                 cut.WaitForAssertion(() =>

--- a/DelegationStation.Tests/Pages/DevicesAddDeviceTests.cs
+++ b/DelegationStation.Tests/Pages/DevicesAddDeviceTests.cs
@@ -2,9 +2,11 @@ using DelegationStation.Interfaces;
 using DelegationStation.Pages;
 using DelegationStationShared.Enums;
 using DelegationStationShared.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.QualityTools.Testing.Fakes;
+using System.Security.Claims;
 
 namespace DelegationStation.Tests.Pages
 {
@@ -20,6 +22,24 @@ namespace DelegationStation.Tests.Pages
     public class DevicesAddDeviceTests : Bunit.TestContext
     {
         private const string DuplicateSerialErrorMessage = "A non-Windows device with this Serial Number already exists.";
+
+        /// <summary>
+        /// Minimal IAuthorizationService that authorizes every request. The Devices page calls
+        /// authorizationService.AuthorizeAsync(user, tag, DeviceTagOperations.Read) inside AddDevice;
+        /// bUnit's AddTestAuthorization() does not satisfy that resource-based operation check.
+        /// The real authorization logic is covered by DeviceTagAuthorizationHandlerTests, so here we
+        /// short-circuit it to focus on the duplicate-serial behavior.
+        /// </summary>
+        private sealed class AlwaysAllowAuthorizationService : IAuthorizationService
+        {
+            public Task<AuthorizationResult> AuthorizeAsync(
+                ClaimsPrincipal user, object? resource, IEnumerable<IAuthorizationRequirement> requirements)
+                => Task.FromResult(AuthorizationResult.Success());
+
+            public Task<AuthorizationResult> AuthorizeAsync(
+                ClaimsPrincipal user, object? resource, string policyName)
+                => Task.FromResult(AuthorizationResult.Success());
+        }
 
         private IRenderedComponent<Devices> SetupComponent(
             List<DeviceTag> deviceTags,
@@ -65,6 +85,10 @@ namespace DelegationStation.Tests.Pages
             Services.AddSingleton<IDeviceTagDBService>(fakeDeviceTagDBService);
             Services.AddSingleton<IDeviceDBService>(fakeDeviceDBService);
             Services.AddSingleton<IConfiguration>(config);
+            // Override bUnit's fake IAuthorizationService so the resource-based
+            // DeviceTagOperations.Read check inside AddDevice succeeds. Registered
+            // after AddTestAuthorization() so this is the resolved instance.
+            Services.AddSingleton<IAuthorizationService>(new AlwaysAllowAuthorizationService());
 
             return RenderComponent<Devices>();
         }
@@ -73,9 +97,6 @@ namespace DelegationStation.Tests.Pages
         /// Fills in the add-device form fields and clicks the Add button.
         /// osValue must be the enum NAME as rendered by @os in the razor (e.g. "Windows", "MacOS", "iOS", "Android").
         /// The option tag renders value=@os which outputs the enum name, not the integer.
-        ///
-        /// InputText components in .NET 8 bind via oninput, so .Input() must be used (not .Change())
-        /// for those fields. InputSelect and native checkboxes use onchange, so .Change() is correct.
         /// </summary>
         private static void FillAndSubmitAddForm(
             IRenderedComponent<Devices> cut,
@@ -84,15 +105,19 @@ namespace DelegationStation.Tests.Pages
             string serialNumber,
             string osValue)
         {
-            // InputText uses @bind-value:event="oninput" in .NET 8 — use .Input() to fire the oninput event
-            cut.Find("#DeviceMake").Input(make);
-            cut.Find("#DeviceModel").Input(model);
-            cut.Find("#SerialNumber").Input(serialNumber);
-            // InputSelect uses onchange — .Change() is correct here
-            cut.Find("#OS").Change(osValue);
-            // Native checkbox with @onchange — .Change() is correct here
+            cut.Find("#DeviceMake").Change(make);
+            cut.Find("#DeviceModel").Change(model);
+            cut.Find("#SerialNumber").Change(serialNumber);
+            // NOTE: id="OS" appears twice on the page -- once for the search filter
+            // (searchDevice.OS) in the table header and once for the add form (newDevice.OS).
+            // Scope to the <form> so we target the add-device OS select, not the search one.
+            cut.Find("form #OS").Change(osValue);
+            // Select the first available tag via its checkbox
             cut.Find(".form-check-input").Change(true);
-            cut.Find("input[value='Add']").Click();
+            // In bUnit, clicking a submit <input> does not trigger the EditForm's
+            // onsubmit (there is no real browser). Submit the form directly so
+            // OnValidSubmit (AddDevice) runs.
+            cut.Find("form").Submit();
         }
 
         [TestMethod]

--- a/DelegationStation.Tests/Pages/DevicesAddDeviceTests.cs
+++ b/DelegationStation.Tests/Pages/DevicesAddDeviceTests.cs
@@ -1,0 +1,207 @@
+using DelegationStation.Interfaces;
+using DelegationStation.Pages;
+using DelegationStationShared.Enums;
+using DelegationStationShared.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.QualityTools.Testing.Fakes;
+
+namespace DelegationStation.Tests.Pages
+{
+    /// <summary>
+    /// Tests that verify the behavior when adding devices, focusing on the non-Windows
+    /// serial number uniqueness enforcement. These are page-level tests: they verify that
+    /// exceptions thrown by IDeviceDBService are surfaced correctly to the user.
+    ///
+    /// The actual DB-level uniqueness check (d.OS > 1 query in DeviceDBService) requires
+    /// integration tests against a real or emulated Cosmos DB instance.
+    /// </summary>
+    [TestClass]
+    public class DevicesAddDeviceTests : Bunit.TestContext
+    {
+        private const string DuplicateSerialErrorMessage = "A non-Windows device with this Serial Number already exists.";
+
+        private IRenderedComponent<Devices> SetupComponent(
+            List<DeviceTag> deviceTags,
+            Func<Device, Task<Device>> addOrUpdateStub,
+            string defaultAdminGroupId = "")
+        {
+            if (string.IsNullOrEmpty(defaultAdminGroupId))
+                defaultAdminGroupId = Guid.NewGuid().ToString();
+
+            var authContext = this.AddTestAuthorization();
+            authContext.SetAuthorized("TEST USER");
+            authContext.SetClaims(
+                new System.Security.Claims.Claim("name", "TEST USER"),
+                new System.Security.Claims.Claim(
+                    "http://schemas.microsoft.com/ws/2008/06/identity/claims/role",
+                    defaultAdminGroupId)
+            );
+
+            var fakeDeviceTagDBService = new DelegationStation.Interfaces.Fakes.StubIDeviceTagDBService()
+            {
+                GetDeviceTagsAsyncIEnumerableOfStringString =
+                    (groupIds, name) => Task.FromResult(deviceTags),
+                GetDeviceTagCountAsyncIEnumerableOfStringString =
+                    (groupIds, name) => Task.FromResult(deviceTags.Count),
+                GetDeviceTagsByPageAsyncIEnumerableOfStringInt32Int32String =
+                    (groupIds, pageNumber, pageSize, name) => Task.FromResult(deviceTags)
+            };
+
+            var fakeDeviceDBService = new DelegationStation.Interfaces.Fakes.StubIDeviceDBService()
+            {
+                GetDevicesAsyncIEnumerableOfStringInt32Int32 =
+                    (groupIds, pageSize, currentPage) => Task.FromResult(new List<Device>()),
+                AddOrUpdateDeviceAsyncDevice = addOrUpdateStub
+            };
+
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    { "DefaultAdminGroupObjectId", defaultAdminGroupId }
+                })
+                .Build();
+
+            Services.AddSingleton<IDeviceTagDBService>(fakeDeviceTagDBService);
+            Services.AddSingleton<IDeviceDBService>(fakeDeviceDBService);
+            Services.AddSingleton<IConfiguration>(config);
+
+            return RenderComponent<Devices>();
+        }
+
+        /// <summary>
+        /// Fills in the add-device form fields and clicks the Add button.
+        /// osValue is the integer string of the DeviceOS enum (e.g. "1"=Windows, "2"=MacOS, "3"=iOS, "4"=Android).
+        /// </summary>
+        private static void FillAndSubmitAddForm(
+            IRenderedComponent<Devices> cut,
+            string make,
+            string model,
+            string serialNumber,
+            string osValue)
+        {
+            cut.Find("#DeviceMake").Change(make);
+            cut.Find("#DeviceModel").Change(model);
+            cut.Find("#SerialNumber").Change(serialNumber);
+            cut.Find("#OS").Change(osValue);
+            // Select the first available tag via its checkbox
+            cut.Find(".form-check-input").Change(true);
+            cut.Find("input[value='Add']").Click();
+        }
+
+        [TestMethod]
+        [DataRow("2", "MacOS")]
+        [DataRow("3", "iOS")]
+        [DataRow("4", "Android")]
+        public void AddDevice_NonWindowsDevice_DuplicateSerial_ShowsErrorMessage(string osValue, string osDisplayName)
+        {
+            using (ShimsContext.Create())
+            {
+                // Arrange
+                var tag = new DeviceTag { Id = Guid.NewGuid(), Name = "TestTag" };
+                var cut = SetupComponent(
+                    new List<DeviceTag> { tag },
+                    device => Task.FromException<Device>(new Exception(DuplicateSerialErrorMessage))
+                );
+
+                // Act
+                FillAndSubmitAddForm(cut, "TestMake", "TestModel", "SN12345", osValue);
+
+                // Assert: the duplicate serial error from the DB service is surfaced to the user
+                cut.WaitForAssertion(() =>
+                    Assert.IsTrue(
+                        cut.Markup.Contains(DuplicateSerialErrorMessage),
+                        $"Expected duplicate serial error for {osDisplayName} device. Markup: {cut.Markup}"
+                    )
+                );
+            }
+        }
+
+        [TestMethod]
+        [DataRow("2", "MacOS")]
+        [DataRow("3", "iOS")]
+        [DataRow("4", "Android")]
+        public void AddDevice_NonWindowsDevice_UniqueSerial_ShowsSuccessMessage(string osValue, string osDisplayName)
+        {
+            using (ShimsContext.Create())
+            {
+                // Arrange
+                var tag = new DeviceTag { Id = Guid.NewGuid(), Name = "TestTag" };
+                var addedDevice = new Device { Make = "TestMake", Model = "TestModel", SerialNumber = "SN-UNIQUE" };
+                var cut = SetupComponent(
+                    new List<DeviceTag> { tag },
+                    device => Task.FromResult(addedDevice)
+                );
+
+                // Act
+                FillAndSubmitAddForm(cut, "TestMake", "TestModel", "SN-UNIQUE", osValue);
+
+                // Assert: a device with a unique serial number is added successfully
+                cut.WaitForAssertion(() =>
+                    Assert.IsTrue(
+                        cut.Markup.Contains("Device added successfully"),
+                        $"Expected success message for {osDisplayName} device with unique serial. Markup: {cut.Markup}"
+                    )
+                );
+            }
+        }
+
+        [TestMethod]
+        public void AddDevice_WindowsDevice_NotBlockedByNonWindowsSerialCheck_ShowsSuccessMessage()
+        {
+            using (ShimsContext.Create())
+            {
+                // Arrange: Windows devices are exempt from the non-Windows serial uniqueness check.
+                // The stub returns success unconditionally; no duplicate-serial exception is thrown.
+                var tag = new DeviceTag { Id = Guid.NewGuid(), Name = "TestTag" };
+                var addedDevice = new Device { Make = "Dell", Model = "Latitude", SerialNumber = "SN12345" };
+                var cut = SetupComponent(
+                    new List<DeviceTag> { tag },
+                    device => Task.FromResult(addedDevice)
+                );
+
+                // Act - "1" = DeviceOS.Windows
+                FillAndSubmitAddForm(cut, "Dell", "Latitude", "SN12345", "1");
+
+                // Assert
+                cut.WaitForAssertion(() =>
+                    Assert.IsTrue(
+                        cut.Markup.Contains("Device added successfully"),
+                        $"Windows device should be added successfully. Markup: {cut.Markup}"
+                    )
+                );
+            }
+        }
+
+        [TestMethod]
+        public void AddDevice_ServiceThrowsDuplicateSerial_ErrorMessageContainsCorrelationId()
+        {
+            using (ShimsContext.Create())
+            {
+                // Arrange
+                var tag = new DeviceTag { Id = Guid.NewGuid(), Name = "TestTag" };
+                var cut = SetupComponent(
+                    new List<DeviceTag> { tag },
+                    device => Task.FromException<Device>(new Exception(DuplicateSerialErrorMessage))
+                );
+
+                // Act - MacOS device
+                FillAndSubmitAddForm(cut, "Apple", "MacBook", "SN12345", "2");
+
+                // Assert: error message is shown in an error-styled alert and includes the correlation ID context
+                cut.WaitForAssertion(() =>
+                {
+                    Assert.IsTrue(
+                        cut.Markup.Contains("Error adding device:"),
+                        "Error message should include the 'Error adding device:' prefix.");
+                    Assert.IsTrue(
+                        cut.Markup.Contains(DuplicateSerialErrorMessage),
+                        "Error message should contain the specific duplicate serial error.");
+                    Assert.IsTrue(
+                        cut.Markup.Contains("Correlation Id"),
+                        "Error message should include a Correlation Id for diagnostics.");
+                });
+            }
+        }
+    }
+}

--- a/DelegationStation/Services/DeviceDBService.cs
+++ b/DelegationStation/Services/DeviceDBService.cs
@@ -279,18 +279,9 @@ namespace DelegationStation.Services
                 QueryDefinition qSerial = new QueryDefinition("SELECT TOP 1 d.id FROM d WHERE d.Type = \"Device\" AND d.OS > 1 AND STRINGEQUALS(d.SerialNumber, @serial, true)");
                 qSerial.WithParameter("@serial", device.SerialNumber);
 
-                bool duplicateSerialExists = false;
                 var serialQueryIterator = this._container.GetItemQueryIterator<dynamic>(qSerial);
-                while (serialQueryIterator.HasMoreResults)
-                {
-                    var qIresponse = await serialQueryIterator.ReadNextAsync();
-                    if (qIresponse.Any())
-                    {
-                        duplicateSerialExists = true;
-                        break;
-                    }
-                }
-                if (duplicateSerialExists)
+                var serialResult = await serialQueryIterator.ReadNextAsync();
+                if (serialResult.Any())
                 {
                     throw new Exception("A non-Windows device with this Serial Number already exists.");
                 }

--- a/DelegationStation/Services/DeviceDBService.cs
+++ b/DelegationStation/Services/DeviceDBService.cs
@@ -275,7 +275,7 @@ namespace DelegationStation.Services
             if (device.OS != DeviceOS.Windows)
             {
                 List<Device> devicesWithSerial = new List<Device>();
-                QueryDefinition qSerial = new QueryDefinition("SELECT * FROM d WHERE d.Type = \"Device\" AND STRINGEQUALS(d.SerialNumber, @serial, true)");
+                QueryDefinition qSerial = new QueryDefinition("SELECT * FROM d WHERE d.Type = \"Device\" AND d.OS != 1 AND STRINGEQUALS(d.SerialNumber, @serial, true)");
                 qSerial.WithParameter("@serial", device.SerialNumber);
 
                 var serialQueryIterator = this._container.GetItemQueryIterator<Device>(qSerial);

--- a/DelegationStation/Services/DeviceDBService.cs
+++ b/DelegationStation/Services/DeviceDBService.cs
@@ -275,7 +275,7 @@ namespace DelegationStation.Services
             if (device.OS != DeviceOS.Windows)
             {
                 List<Device> devicesWithSerial = new List<Device>();
-                QueryDefinition qSerial = new QueryDefinition("SELECT * FROM d WHERE d.Type = \"Device\" AND d.OS != 1 AND STRINGEQUALS(d.SerialNumber, @serial, true)");
+                QueryDefinition qSerial = new QueryDefinition("SELECT * FROM d WHERE d.Type = \"Device\" AND d.OS > 1 AND STRINGEQUALS(d.SerialNumber, @serial, true)");
                 qSerial.WithParameter("@serial", device.SerialNumber);
 
                 var serialQueryIterator = this._container.GetItemQueryIterator<Device>(qSerial);

--- a/DelegationStation/Services/DeviceDBService.cs
+++ b/DelegationStation/Services/DeviceDBService.cs
@@ -275,6 +275,7 @@ namespace DelegationStation.Services
             if (device.OS != DeviceOS.Windows)
             {
                 List<Device> devicesWithSerial = new List<Device>();
+                // d.OS > 1 excludes both Unknown (0) and Windows (1), checking only MacOS, iOS, and Android
                 QueryDefinition qSerial = new QueryDefinition("SELECT * FROM d WHERE d.Type = \"Device\" AND d.OS > 1 AND STRINGEQUALS(d.SerialNumber, @serial, true)");
                 qSerial.WithParameter("@serial", device.SerialNumber);
 

--- a/DelegationStation/Services/DeviceDBService.cs
+++ b/DelegationStation/Services/DeviceDBService.cs
@@ -274,18 +274,23 @@ namespace DelegationStation.Services
             // For non-Windows devices, serial number must be globally unique regardless of Make/Model
             if (device.OS != DeviceOS.Windows)
             {
-                List<Device> devicesWithSerial = new List<Device>();
+                // SELECT TOP 1 with a single field: stops at first match and minimizes RU cost.
                 // d.OS > 1 excludes both Unknown (0) and Windows (1), checking only MacOS, iOS, and Android
-                QueryDefinition qSerial = new QueryDefinition("SELECT * FROM d WHERE d.Type = \"Device\" AND d.OS > 1 AND STRINGEQUALS(d.SerialNumber, @serial, true)");
+                QueryDefinition qSerial = new QueryDefinition("SELECT TOP 1 d.id FROM d WHERE d.Type = \"Device\" AND d.OS > 1 AND STRINGEQUALS(d.SerialNumber, @serial, true)");
                 qSerial.WithParameter("@serial", device.SerialNumber);
 
-                var serialQueryIterator = this._container.GetItemQueryIterator<Device>(qSerial);
+                bool duplicateSerialExists = false;
+                var serialQueryIterator = this._container.GetItemQueryIterator<dynamic>(qSerial);
                 while (serialQueryIterator.HasMoreResults)
                 {
                     var qIresponse = await serialQueryIterator.ReadNextAsync();
-                    devicesWithSerial.AddRange(qIresponse.ToList());
+                    if (qIresponse.Any())
+                    {
+                        duplicateSerialExists = true;
+                        break;
+                    }
                 }
-                if (devicesWithSerial.Count != 0)
+                if (duplicateSerialExists)
                 {
                     throw new Exception("A non-Windows device with this Serial Number already exists.");
                 }

--- a/DelegationStation/Services/DeviceDBService.cs
+++ b/DelegationStation/Services/DeviceDBService.cs
@@ -272,7 +272,7 @@ namespace DelegationStation.Services
             device.SerialNumber = device.SerialNumber.Trim();
 
             // For non-Windows devices, serial number must be globally unique regardless of Make/Model
-            if (device.OS != DeviceOS.Windows)
+            if (device.OS != DeviceOS.Windows && device.OS != DeviceOS.Unknown)
             {
                 // SELECT TOP 1 with a single field: stops at first match and minimizes RU cost.
                 // d.OS > 1 excludes both Unknown (0) and Windows (1), checking only MacOS, iOS, and Android

--- a/DelegationStation/Services/DeviceDBService.cs
+++ b/DelegationStation/Services/DeviceDBService.cs
@@ -271,6 +271,25 @@ namespace DelegationStation.Services
             device.Model = device.Model.Trim();
             device.SerialNumber = device.SerialNumber.Trim();
 
+            // For non-Windows devices, serial number must be globally unique regardless of Make/Model
+            if (device.OS != DeviceOS.Windows)
+            {
+                List<Device> devicesWithSerial = new List<Device>();
+                QueryDefinition qSerial = new QueryDefinition("SELECT * FROM d WHERE d.Type = \"Device\" AND STRINGEQUALS(d.SerialNumber, @serial, true)");
+                qSerial.WithParameter("@serial", device.SerialNumber);
+
+                var serialQueryIterator = this._container.GetItemQueryIterator<Device>(qSerial);
+                while (serialQueryIterator.HasMoreResults)
+                {
+                    var qIresponse = await serialQueryIterator.ReadNextAsync();
+                    devicesWithSerial.AddRange(qIresponse.ToList());
+                }
+                if (devicesWithSerial.Count != 0)
+                {
+                    throw new Exception("A non-Windows device with this Serial Number already exists.");
+                }
+            }
+
             // Confirm DB does not already contain device - treating fields as case insensitive
             List<Device> devices = new List<Device>();
             QueryDefinition q = new QueryDefinition("SELECT * FROM d WHERE d.Type = \"Device\" AND STRINGEQUALS(d.Make,@make,true) AND STRINGEQUALS(d.Model,@model,true) AND STRINGEQUALS(d.SerialNumber,@serial,true)");


### PR DESCRIPTION
## Why

Non-Windows devices (MacOS, iOS, Android) tend to have globally unique serial numbers. Previously, the uniqueness check in `AddOrUpdateDeviceAsync` only matched on Make + Model + SerialNumber combined, which meant two devices with different makes/models could be entered with the same serial number. This PR adds an upfront guard to block that.

## What changed

A new Cosmos DB query runs before the existing Make+Model+SerialNumber duplicate check in `DeviceDBService.AddOrUpdateDeviceAsync`. For any device with OS > 1 (MacOS, iOS, or Android), it queries for any existing device sharing the same serial number regardless of Make or Model. If a match is found, the add is rejected with a clear error message.

- `d.OS > 1` intentionally excludes both `Unknown (0)` and `Windows (1)` -- Windows devices are exempt because their serial numbers are not guaranteed to be globally unique across manufacturers, and Unknown-OS devices are also excluded.
- The existing Make+Model+SerialNumber uniqueness check still runs for all device types as a second layer.
- The error propagates through the existing exception-handling paths in both the single-device (`Devices.razor`) and bulk-upload (`DevicesBulkAction.razor`) flows -- no UI changes required.