### PR TITLE
Feature/device with tag count

### DIFF
--- a/DelegationStation/Pages/TagEdit.razor
+++ b/DelegationStation/Pages/TagEdit.razor
@@ -16,7 +16,7 @@
 
 @attribute [Authorize]
 
-<h3>Tag Edit</h3>
+<h2>Tag Edit</h2>
 
 <AuthorizeView Context="authContext" Policy="TagView" Resource="_tag">
     <Authorized>
@@ -29,6 +29,7 @@
             <EditForm Context="OutsideForm" Model="@tag" OnSubmit="Save">
                 <h3>@tag.Name</h3>
                 <h4>@tag.Description</h4>
+                <h4>@(deviceCount > -1 ? $"Device count: {deviceCount}" : "Unable to retrieve device count")</h4>
                 <br />
                 <hr />
                 <AuthorizeView Context="TagUpdateContext" Policy="TagUpdate" Resource="_tag">
@@ -423,7 +424,7 @@
                     <p class="text-success">@tagSuccessMessage</p>
                 }
 
-                <p>@(deviceCount > -1 ? $"Device count: {deviceCount}" : "Unable to retrieve device count")</p>
+                
 
                 <DisplayMessage Message=@securityGroupSearchMessage />
 

--- a/DelegationStation/Pages/Tags.razor
+++ b/DelegationStation/Pages/Tags.razor
@@ -45,12 +45,14 @@
                 <tr>
                     <th>Tag Name</th>
                     <th>Tag Description</th>
+                    <th>Devices with Tag</th>
                     <th></th>
                 </tr>
                 <tr>
                     <td>
                         <input type="text" @bind="searchTag.Name" class="form-control" placeholder="Tag Name" />
                     </td>
+                    <td></td>
                     <td></td>
                     <td>
                         <button type="button" class="btn btn-primary" @onclick=@(() => GetTagsSearch())>Search</button>
@@ -81,6 +83,8 @@
                         <tr>
                             <td class="clickable" @onclick=@(() => nav.NavigateTo($"/TagEdit/{tag.Id}"))>@tag.Name</td>
                             <td class="clickable" @onclick=@(() => nav.NavigateTo($"/TagEdit/{tag.Id}"))>@tag.Description</td>
+                            <td class="clickable" @onclick=@(() => nav.NavigateTo($"/TagEdit/{tag.Id}"))>@(deviceCounts.ContainsKey(tag.Id) ? 
+                                (deviceCounts[tag.Id] > -1 ? deviceCounts[tag.Id].ToString() : "Unable to retrieve device count") : "Loading...")</td>
                             <td>
                                 <button type="button" class="btn btn-primary" @onclick=@(() => nav.NavigateTo($"/TagEdit/{tag.Id}"))>
                                     <span class="oi oi-pencil" aria-hidden="true"></span> Edit

--- a/DelegationStation/Pages/Tags.razor
+++ b/DelegationStation/Pages/Tags.razor
@@ -63,7 +63,7 @@
                 @if (tagsLoading)
                 {
                     <tr>
-                        <td colspan="3">
+                        <td colspan="4">
                             <div class="spinner-border" role="status">
                                 <span class="visually-hidden">Loading...</span>
                             </div>
@@ -73,7 +73,7 @@
                 else if (deviceTags.Count == 0)
                 {
                     <tr>
-                        <td colspan="3">No tags found.</td>
+                        <td colspan="4">No tags found.</td>
                     </tr>
                 }
                 else

--- a/DelegationStation/Pages/Tags.razor.cs
+++ b/DelegationStation/Pages/Tags.razor.cs
@@ -20,6 +20,7 @@ namespace DelegationStation.Pages
             // default to set for new tags only
             CorpIDSyncEnabled = true
         };
+        private Dictionary<Guid, int> deviceCounts = new Dictionary<Guid, int>();
         private string userMessage = string.Empty;
         private bool tagsLoading = true;
         private int TotalTags = 0;
@@ -122,6 +123,7 @@ namespace DelegationStation.Pages
                 TotalPages = (int)Math.Ceiling((decimal)TotalTags / PageSize);
 
                 deviceTags = await deviceTagDBService.GetDeviceTagsByPageAsync(groups, PageNumber, PageSize, searchTag.Name);
+                await GetDevicesCount();
             }
             catch (Exception ex)
             {
@@ -131,6 +133,22 @@ namespace DelegationStation.Pages
             finally
             {
                 tagsLoading = false;
+            }
+        }
+        private async Task GetDevicesCount()
+        {
+            foreach (var tag in deviceTags)
+            {
+                try
+                {
+                    int count = await deviceTagDBService.GetDeviceCountByTagIdAsync(tag.Id.ToString());
+                    deviceCounts[tag.Id] = count;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError($"Error retrieving device count for tag {tag.Name} ({tag.Id}).\n{ex.Message}\nUser: {userName} {userId}");
+                    deviceCounts[tag.Id] = -1; // Indicate an error occurred
+                }
             }
         }
 

--- a/DelegationStation/Pages/Tags.razor.cs
+++ b/DelegationStation/Pages/Tags.razor.cs
@@ -137,18 +137,25 @@ namespace DelegationStation.Pages
         }
         private async Task GetDevicesCount()
         {
-            foreach (var tag in deviceTags)
+            deviceCounts.Clear();
+
+            var countTasks = deviceTags.Select(async tag =>
             {
                 try
                 {
-                    int count = await deviceTagDBService.GetDeviceCountByTagIdAsync(tag.Id.ToString());
-                    deviceCounts[tag.Id] = count;
+                    var count = await deviceTagDBService.GetDeviceCountByTagIdAsync(tag.Id.ToString());
+                    return (Id: tag.Id, Count: count);
                 }
                 catch (Exception ex)
                 {
-                    logger.LogError($"Error retrieving device count for tag {tag.Name} ({tag.Id}).\n{ex.Message}\nUser: {userName} {userId}");
-                    deviceCounts[tag.Id] = -1; // Indicate an error occurred
+                    logger.LogError(ex, "Error retrieving device count for tag {TagName} ({TagId}). User: {UserName} {UserId}", tag.Name, tag.Id, userName, userId);
+                    return (Id: tag.Id, Count: -1);
                 }
+            });
+
+            foreach (var result in await Task.WhenAll(countTasks))
+            {
+                deviceCounts[result.Id] = result.Count;
             }
         }
 

--- a/DelegationStationTests/Pages/TagTests.cs
+++ b/DelegationStationTests/Pages/TagTests.cs
@@ -71,8 +71,10 @@ namespace DelegationStationTests.Pages
                 Assert.IsTrue(cut.Markup.Contains("testDescription1</td>"), "Tag1 description should be rendered in the table.");
                 Assert.IsTrue(cut.Markup.Contains("testName2</td>"), "Tag2 name should be rendered in the table.");
                 Assert.IsTrue(cut.Markup.Contains("testDescription2</td>"), "Tag2 description should be rendered in the table.");
-                Assert.IsTrue(cut.Markup.Contains(">5</td>"), $"Tag1 device count should be rendered in the table.\nActual:\n{cut.Markup}");
-                Assert.IsTrue(cut.Markup.Contains(">7</td>"), $"Tag2 device count should be rendered in the table.\nActual:\n{cut.Markup}");
+                var row1 = cut.FindAll("tbody tr").Single(r => r.TextContent.Contains("testName1"));
+                var row2 = cut.FindAll("tbody tr").Single(r => r.TextContent.Contains("testName2"));
+                Assert.IsTrue(row1.TextContent.Contains("5"), $"Tag1 device count should be rendered in the table row.\nActual:\n{cut.Markup}");
+                Assert.IsTrue(row2.TextContent.Contains("7"), $"Tag2 device count should be rendered in the table row.\nActual:\n{cut.Markup}");
             }
         }
 

--- a/DelegationStationTests/Pages/TagTests.cs
+++ b/DelegationStationTests/Pages/TagTests.cs
@@ -41,7 +41,9 @@ namespace DelegationStationTests.Pages
                     GetDeviceTagCountAsyncIEnumerableOfStringString =
                         (groupIds, name) => Task.FromResult(2),
                     GetDeviceTagsByPageAsyncIEnumerableOfStringInt32Int32String =
-                        (groupIds, pageNumber, pageSize, name) => Task.FromResult(deviceTags)
+                        (groupIds, pageNumber, pageSize, name) => Task.FromResult(deviceTags),
+                    GetDeviceCountByTagIdAsyncString =
+                        (tagId) => Task.FromResult(tagId == deviceTag1.Id.ToString() ? 5 : 7)
                 };
 
                 var myConfiguration = new Dictionary<string, string?>
@@ -69,6 +71,61 @@ namespace DelegationStationTests.Pages
                 Assert.IsTrue(cut.Markup.Contains("testDescription1</td>"), "Tag1 description should be rendered in the table.");
                 Assert.IsTrue(cut.Markup.Contains("testName2</td>"), "Tag2 name should be rendered in the table.");
                 Assert.IsTrue(cut.Markup.Contains("testDescription2</td>"), "Tag2 description should be rendered in the table.");
+                Assert.IsTrue(cut.Markup.Contains(">5</td>"), $"Tag1 device count should be rendered in the table.\nActual:\n{cut.Markup}");
+                Assert.IsTrue(cut.Markup.Contains(">7</td>"), $"Tag2 device count should be rendered in the table.\nActual:\n{cut.Markup}");
+            }
+        }
+
+        [TestMethod]
+        public void TagsShouldRenderErrorForFailedDeviceCount()
+        {
+            using (ShimsContext.Create())
+            {
+                // Arrange
+                Guid defaultId = Guid.NewGuid();
+                var authContext = this.AddTestAuthorization();
+                authContext.SetAuthorized("TEST USER");
+                authContext.SetClaims(new System.Security.Claims.Claim("name", "TEST USER"));
+                authContext.SetClaims(new System.Security.Claims.Claim("http://schemas.microsoft.com/ws/2008/06/identity/claims/role", defaultId.ToString()));
+
+                List<DeviceTag> deviceTags = new List<DeviceTag>();
+                DeviceTag deviceTag1 = new DeviceTag();
+                deviceTag1.Name = "testName1";
+                deviceTag1.Description = "testDescription1";
+                deviceTags.Add(deviceTag1);
+
+                var fakeDeviceTagDBService = new DelegationStation.Interfaces.Fakes.StubIDeviceTagDBService()
+                {
+                    CurrentSearchGet = () => new DelegationStation.Services.DeviceTagSearch()
+                        { pageNumber = 1, pageSize = 10, name = string.Empty },
+                    GetDeviceTagsAsyncIEnumerableOfStringString =
+                        (groupIds, name) => Task.FromResult(deviceTags),
+                    GetDeviceTagCountAsyncIEnumerableOfStringString =
+                        (groupIds, name) => Task.FromResult(1),
+                    GetDeviceTagsByPageAsyncIEnumerableOfStringInt32Int32String =
+                        (groupIds, pageNumber, pageSize, name) => Task.FromResult(deviceTags),
+                    GetDeviceCountByTagIdAsyncString =
+                        (tagId) => throw new Exception("Simulated failure")
+                };
+
+                var myConfiguration = new Dictionary<string, string?>
+                {
+                    {"DefaultAdminGroupObjectId", defaultId.ToString()}
+                };
+
+                var configuration = new ConfigurationBuilder()
+                    .AddInMemoryCollection(myConfiguration)
+                    .Build();
+
+                Services.AddSingleton<IDeviceTagDBService>(fakeDeviceTagDBService);
+                Services.AddSingleton<Microsoft.Extensions.Configuration.IConfiguration>(configuration);
+
+                // Act
+                var cut = RenderComponent<Tags>();
+
+                // Assert
+                Assert.IsTrue(cut.Markup.Contains("Unable to retrieve device count"),
+                    $"Error text should be rendered when device count retrieval fails.\nActual:\n{cut.Markup}");
             }
         }
 


### PR DESCRIPTION
Moved device count on TagEdit page to be more obvious/useful.
<img width="1416" height="450" alt="image" src="https://github.com/user-attachments/assets/081fc813-003e-44ae-8d29-dc1ed5ad6330" />


Added device count field to Tags page.
<img width="1376" height="440" alt="image" src="https://github.com/user-attachments/assets/8764fdfc-5ee2-473c-a146-ba324e7da8d6" />
