### PR TITLE
Updated to use h2.

### DIFF
--- a/DelegationStationTests/Pages/TagEditTests.cs
+++ b/DelegationStationTests/Pages/TagEditTests.cs
@@ -268,7 +268,7 @@ namespace DelegationStationTests.Pages
                 var cut = RenderComponent<TagEdit>();
 
                 // Assert
-                string match = @"<h3>Tag Edit</h3>.*";
+                string match = @"<h2>Tag Edit</h2>.*";
                 Assert.IsTrue(Regex.IsMatch(cut.Markup, match), $"Expected Match:\n{match}\nActual:\n{cut.Markup}");
                 match = @"<h3>Not Authorized</h3>";
                 Assert.IsTrue(Regex.IsMatch(cut.Markup, match), $"Expected Match:\n{match}\nActual:\n{cut.Markup}");
@@ -296,7 +296,7 @@ namespace DelegationStationTests.Pages
 
 
             // Assert
-            string match = @"<h3>Tag Edit</h3>.*";
+            string match = @"<h2>Tag Edit</h2>.*";
             Assert.IsTrue(Regex.IsMatch(cut.Markup, match), $"Expected Match:\n{match}\nActual:\n{cut.Markup}");
             match = @"<h3>Error in navigation path</h3>";
             Assert.IsTrue(Regex.IsMatch(cut.Markup, match), $"Expected Match:\n{match}\nActual:\n{cut.Markup}");


### PR DESCRIPTION
Unit test issues missed in a previous PR. Just about a header setting in a render fragment.